### PR TITLE
Fix the exact-likelihood criteria: measurable fallback, consistent n, no reward for boundary candidates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - Unreleased
 
 ### Fixed
+- **Criterion fallback no longer rewards boundary candidates.** When the exact
+  Gaussian likelihood is not computable (roots at the boundary), the criterion falls
+  back to the CSS likelihood — which is evaluated on the conditioned sample
+  (`T - lb + 1` observations vs `T` for the exact one) and is therefore less
+  negative, granting tens of AICc units of advantage precisely to near-nonstationary
+  candidates. The search criterion (`getInformationCriteriaFunction`) now adds a
+  fixed penalty to fallback-scored candidates, imposing a two-tier order analogous
+  to `forecast::myarima`'s `Inf` on non-finite likelihoods: an exact-scored
+  candidate always outranks a fallback-scored one, while fallback-scored candidates
+  remain comparable among themselves (same conditioning sample). The public
+  `aic`/`aicc`/`bic` accessors are unaffected. The fallback is recorded in
+  `model.metadata["criterionFallback"]` so its rate is measurable.
+- **AICc/BIC sample size matches the likelihood actually scored.** The small-sample
+  correction and the BIC `log(n)` factor used `n = length(observedResiduals)`
+  (the CSS-conditioned count) even when the likelihood was the exact one evaluated
+  on the full differenced sample — an undocumented extra size penalty, growing
+  with `K`, that `forecast::Arima` does not have. Both now use the sample size of
+  whichever likelihood was used.
+- **`criterionLoglike` no longer swallows exceptions.** `exactLoglike`'s contract is
+  `nothing`-on-refusal, so the blanket `try/catch` around it could only mask bugs
+  (`MethodError`, `UndefVarError`) and made the fallback rate uninterpretable;
+  model types without `exactLoglike` fall back via `applicable`.
 - **Internal data scaling (numerical conditioning).** `fit!` now solves in units of
   the differenced series' standard deviation and maps the scale-dependent estimates
   (constant, trend, exogenous coefficients, residuals, σ², fitted and imputed values)

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -145,11 +145,17 @@ Numero de observacoes da verossimilhanca EXATA: o comprimento da serie diferenci
 `n` que o `stats::arima` usa. Nao confundir com `length(observedResiduals)`, que desconta o
 conditioning da CSS.
 
+Calculado por aritmetica (`n - d - D*s`) e nao por `length(values(differentiate(...)))`: a
+versao com `differentiate` alocava a serie diferenciada inteira so para medir o comprimento,
+custando ~7.5us por avaliacao de criterio (medido: 164.6us vs 157.1us por `aicc`, mediana de
+7 baterias de 3000 chamadas). A equivalencia das duas formas esta travada em
+`test/exact_likelihood.jl`.
+
 Sem anotacao de tipo porque `fit.jl` e incluido antes de `models/sarima.jl` definir
 `SARIMAModel`; so e chamada no caminho exato, que exige `applicable(exactLoglike, model)`.
 """
 criterionSampleSize(model) =
-    length(values(differentiate(model.y, model.d, model.D, model.seasonality)))
+    length(values(model.y)) - model.d - model.D * model.seasonality
 
 """
 Penalidade somada ao criterio de um candidato de BUSCA cujo criterio veio do recuo CSS.

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -103,14 +103,95 @@ O recuo existe porque `exactLoglike` devolve `nothing` de proposito em vez de um
 errado (ponto nao estacionario, autocovariancia sem positividade definida, truncagem dos psi
 mordendo). Nesses casos o criterio volta a ser o de antes — comportamento degradado, nunca
 silenciosamente incorreto.
+
+Sem `try/catch`: o contrato de `exactLoglike` ja e nothing-em-recusa, entao qualquer excecao
+aqui e bug e deve subir — um `catch` largo mascararia exatamente a classe de erro
+(`MethodError`, `UndefVarError`) que ja mordeu este arquivo, e tornaria a taxa de recuo
+impossivel de interpretar. Tipos de modelo sem `exactLoglike` recuam via `applicable`.
 """
 function criterionLoglike(model::SarimaxModel)
-    exact = try
-        exactLoglike(model)
-    catch
-        nothing
+    return first(criterionLoglikeAndN(model))
+end
+
+"""
+    criterionLoglikeAndN(model) -> (loglike, n, usedExact)
+
+Nucleo de [`criterionLoglike`](@ref): devolve tambem o TAMANHO DA AMOSTRA sobre o qual a
+log-verossimilhanca foi avaliada, e qual caminho foi usado.
+
+O `n` importa porque as duas verossimilhancas nao vivem na mesma amostra: a exata e avaliada
+sobre a serie diferenciada inteira (`T`), enquanto a CSS vive nos residuos condicionados
+(`length(observedResiduals) = T - lb + 1`, com `lb` ate 30 nos defaults mensais de `auto`).
+Correcoes de amostra finita (AICc) e o fator `log(n)` do BIC devem usar o `n` da
+verossimilhanca efetivamente usada — caso contrario o criterio aplica uma penalidade de
+tamanho extra, crescente em K, que o `forecast::Arima` nao tem.
+
+O recuo e registrado em `model.metadata["criterionFallback"]` para ser mensuravel.
+"""
+function criterionLoglikeAndN(model::SarimaxModel)
+    exact = applicable(exactLoglike, model) ? exactLoglike(model) : nothing
+    usedExact = !isnothing(exact)
+    if hasproperty(model, :metadata) && isa(model.metadata, AbstractDict)
+        model.metadata["criterionFallback"] = !usedExact
     end
-    return isnothing(exact) ? loglike(model) : exact
+    usedExact && return exact, criterionSampleSize(model), true
+    return loglike(model), length(observedResiduals(model)), false
+end
+
+"""
+    criterionSampleSize(model) -> Int
+
+Numero de observacoes da verossimilhanca EXATA: o comprimento da serie diferenciada, que e o
+`n` que o `stats::arima` usa. Nao confundir com `length(observedResiduals)`, que desconta o
+conditioning da CSS.
+
+Sem anotacao de tipo porque `fit.jl` e incluido antes de `models/sarima.jl` definir
+`SARIMAModel`; so e chamada no caminho exato, que exige `applicable(exactLoglike, model)`.
+"""
+criterionSampleSize(model) =
+    length(values(differentiate(model.y, model.d, model.D, model.seasonality)))
+
+"""
+Penalidade somada ao criterio de um candidato de BUSCA cujo criterio veio do recuo CSS.
+
+Sem ela, o recuo premia exatamente os candidatos errados: a CSS e avaliada sobre menos
+observacoes que a exata (`T - lb + 1` vs `T`), logo e menos negativa, logo AICc menor — e o
+que dispara o recuo e raiz perto da fronteira. Um candidato quase nao estacionario ganharia
+dezenas de unidades de AICc de vantagem por nao ter verossimilhanca exata computavel.
+
+A penalidade impoe uma ordem em dois niveis, analoga a do `myarima` (que devolve `Inf` quando
+a verossimilhanca nao e finita): candidato com verossimilhanca exata sempre vence candidato
+sem; entre candidatos sem, a comparacao CSS continua valida porque todos condicionam na mesma
+amostra (`searchLb`). Aditiva em vez de `Inf` para a busca nunca ficar sem selecao quando a
+exata falha em todos os candidatos (series curtas ou patologicas).
+
+So se aplica a SELECAO ([`searchCriterionFunction`](@ref)); os acessores publicos `aic`,
+`aicc` e `bic` continuam devolvendo o valor com recuo documentado.
+"""
+const FALLBACK_CRITERION_PENALTY = 1e10
+
+"""
+    searchCriterionFunction(baseCriterion) -> Function
+
+Envolve `aic`/`aicc`/`bic` com a semantica de SELECAO: soma
+[`FALLBACK_CRITERION_PENALTY`](@ref) quando o criterio do candidato veio do recuo CSS
+(lido de `model.metadata["criterionFallback"]`, gravado por [`criterionLoglikeAndN`](@ref)
+na propria avaliacao do criterio).
+"""
+function searchCriterionFunction(baseCriterion::Function)
+    # Transparente a argumentos: alem da forma de modelo, `aic`/`aicc`/`bic` tem formas
+    # escalares ((K, ll), (T, K, ll)) que continuam acessiveis pela funcao retornada; a
+    # penalidade so se aplica quando o primeiro argumento e um modelo.
+    return function (args...; kwargs...)
+        value = baseCriterion(args...; kwargs...)
+        model = first(args)
+        fallback =
+            model isa SarimaxModel &&
+            hasproperty(model, :metadata) &&
+            isa(model.metadata, AbstractDict) &&
+            get(model.metadata, "criterionFallback", false)
+        return fallback ? value + FALLBACK_CRITERION_PENALTY : value
+    end
 end
 
 """
@@ -161,8 +242,13 @@ function aicc(model::SarimaxModel; offset::Union{AbstractFloat,Nothing} = nothin
     !has_hyperparameters_methods(typeof(model)) &&
         throw(MissingMethodImplementation("get_hyperparameters_number"))
     K = isnothing(K) ? get_hyperparameters_number(model) : K
-    n = length(observedResiduals(model))
-    return aic(model; offset = offset, K = K) + ((2 * K * K + 2 * K) / (n - K - 1))
+    offsetValue = isnothing(offset) ? 0.0 : offset
+    # O `n` da correcao e o da amostra da verossimilhanca efetivamente usada: `T` (serie
+    # diferenciada inteira) no caminho exato, `length(observedResiduals)` no recuo CSS.
+    # Misturar — corrigir uma verossimilhanca sobre T com um n condicionado menor — cobra
+    # uma penalidade extra crescente em K que o `forecast::Arima` nao tem.
+    ll, n, _ = criterionLoglikeAndN(model)
+    return 2 * K - 2 * ll + offsetValue + ((2 * K * K + 2 * K) / (n - K - 1))
 end
 
 """
@@ -185,9 +271,10 @@ function bic(model::SarimaxModel; offset::Union{AbstractFloat,Nothing} = nothing
     !has_hyperparameters_methods(typeof(model)) &&
         throw(MissingMethodImplementation("get_hyperparameters_number"))
     K = isnothing(K) ? get_hyperparameters_number(model) : K
-    n = length(observedResiduals(model))
     offsetValue = isnothing(offset) ? 0.0 : offset
-    return K * log(n) - 2 * criterionLoglike(model) + offsetValue
+    # Mesmo `n` da verossimilhanca usada — ver `aicc`.
+    ll, n, _ = criterionLoglikeAndN(model)
+    return K * log(n) - 2 * ll + offsetValue
 end
 
 

--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -715,9 +715,10 @@ function get_hyperparameters_number(model::SARIMAModel)
     k = (model.allowMean) ? 1 : 0
     k = (model.allowDrift) ? k + 1 : k
     β = isnothing(model.exog) ? 0 : length(colnames(model.exog))
-    # `K = ncoef + 1` (o +1 e sigma^2), exatamente a convencao do `forecast::Arima`. O `n` dos
-    # criterios ja casa: os residuos vivem na serie DIFERENCIADA (`T = length(diffY)`), entao
-    # `length(observedResiduals)` ja e o `n* = n - d - D*m` do R.
+    # `K = ncoef + 1` (o +1 e sigma^2), exatamente a convencao do `forecast::Arima`. O `n`
+    # dos criterios vem de `criterionLoglikeAndN`: `T = length(diffY)` (o `n* = n - d - D*m`
+    # do R) quando a verossimilhanca exata e usada, e `length(observedResiduals) = T - lb + 1`
+    # no recuo CSS — os residuos condicionados descontam o `lb`, entao NAO sao o `n*` do R.
     #
     # O `nPresampleFree` NAO entra mais. Ele cobrava os valores pre-amostrais livres do
     # `:free` como se fossem parametros, para impedir que candidatos sazonais de ordem alta
@@ -2955,9 +2956,13 @@ function auto(
     maxQ =
         (seasonality == 1) ? 0 : min(maxQ, floor(Int, length(values(y)) / 3 * seasonality))
 
-    # All search candidates are conditioned on the same pre-sample length so
-    # that their CSS likelihoods (and hence information criteria) are computed
-    # on the same effective sample.
+    # All search candidates are conditioned on the same pre-sample length so that their CSS
+    # objectives — and the CSS likelihoods of the criterion FALLBACK path — live on the same
+    # effective sample. Since the criteria moved to the exact likelihood (evaluated on the
+    # full differenced sample regardless of conditioning), this common `lb` no longer shapes
+    # the primary criterion path; it still governs the estimation objective and keeps the
+    # fallback comparisons consistent. Whether it should be removed altogether is an open
+    # question that needs M4-scale measurement (it changes the estimation, not just scoring).
     # With :free initialization every candidate already scores on the full differenced
     # sample (pre-sample values are estimated), so no common conditioning is needed.
     searchLb =
@@ -3129,24 +3134,28 @@ end
 """
     getInformationCriteriaFunction(informationCriteria)
 
-Returns the information criteria function corresponding to the given `informationCriteria`.
+Returns the SELECTION criterion function for the search: `aic`/`aicc`/`bic` wrapped by
+[`searchCriterionFunction`](@ref), so that candidates whose criterion came from the CSS
+fallback (no computable exact likelihood — typically roots at the boundary) are penalized
+and can never outrank a candidate scored by the exact likelihood. The public `aic`/`aicc`/
+`bic` accessors are NOT affected.
 
 # Arguments
 - `informationCriteria::String`: The name of the information criteria ("aic", "aicc", or "bic").
 
 # Returns
-- `Function`: The information criteria function corresponding to the input.
+- `Function`: The selection criterion function corresponding to the input.
 
 # Throws
 - `ArgumentError`: If the provided `informationCriteria` is not one of "aic", "aicc", or "bic".
 """
 function getInformationCriteriaFunction(informationCriteria::String)
     if informationCriteria == "aic"
-        return aic
+        return searchCriterionFunction(aic)
     elseif informationCriteria == "aicc"
-        return aicc
+        return searchCriterionFunction(aicc)
     elseif informationCriteria == "bic"
-        return bic
+        return searchCriterionFunction(bic)
     end
     throw(ArgumentError("The information criteria '$informationCriteria' is not supported"))
 end

--- a/test/exact_likelihood.jl
+++ b/test/exact_likelihood.jl
@@ -115,10 +115,10 @@ end
         end
     end
 
-    @testset "n do AICc casa com a amostra da verossimilhanca [defeito conhecido]" begin
-        # `aicc` corrige com n = length(observedResiduals) = T - lb + 1, mas a
-        # verossimilhanca exata que entra no criterio e avaliada sobre os T pontos da
-        # serie diferenciada. A correcao deveria usar o n da verossimilhanca usada.
+    @testset "n do AICc casa com a amostra da verossimilhanca" begin
+        # A verossimilhanca exata que entra no criterio e avaliada sobre os T pontos da
+        # serie diferenciada; a correcao de amostra pequena deve usar esse mesmo n, nao o
+        # `length(observedResiduals) = T - lb + 1` do conditioning da CSS.
         y = TimeArray(collect(Date(2000, 1, 1):Month(1):Date(2006, 12, 1)), randn(rng, 84))
         m = SARIMA(y, 2, 0, 0; allowMean = false)
         fit!(m)  # :zeroed => residualLags = p = 2 => lb = 3
@@ -128,9 +128,35 @@ end
             @test nRes < T   # premissa do teste: a truncagem existe de fato
             K = Sarimax.get_hyperparameters_number(m)
             correctionOn(n) = (2K^2 + 2K) / (n - K - 1)
-            @test aicc(m) ≈ aic(m) + correctionOn(nRes)          # comportamento atual
-            @test_broken aicc(m) ≈ aic(m) + correctionOn(T)       # comportamento correto
+            @test aicc(m) ≈ aic(m) + correctionOn(T)
+            @test aicc(m) ≉ aic(m) + correctionOn(nRes)   # o defeito antigo, nao regredir
+            llAndN = Sarimax.criterionLoglikeAndN(m)
+            @test llAndN[2] == T
+            @test llAndN[3] === true
+            @test m.metadata["criterionFallback"] === false
         end
+    end
+
+    @testset "selecao: recuo CSS nunca vence candidato com exata" begin
+        # O criterio de BUSCA (getInformationCriteriaFunction) penaliza candidatos cujo
+        # criterio veio do recuo; os acessores publicos nao mudam.
+        y = TimeArray(collect(Date(2000, 1, 1):Month(1):Date(2006, 12, 1)), randn(rng, 84))
+        m = SARIMA(y, 1, 0, 0; allowMean = false)
+        fit!(m)
+        searchAicc = Sarimax.getInformationCriteriaFunction("aicc")
+        publicValue = aicc(m)
+        if !isnothing(Sarimax.exactLoglike(m))
+            @test searchAicc(m) ≈ publicValue          # caminho exato: sem penalidade
+        end
+        # forca o recuo: coeficiente AR na fronteira mantido fixo
+        mBoundary = SARIMA(y; arCoefficients = [0.99999], allowMean = false)
+        fit!(mBoundary)
+        @test isnothing(Sarimax.exactLoglike(mBoundary))
+        publicBoundary = aicc(mBoundary)          # avalia o criterio e grava o metadata
+        @test publicBoundary isa AbstractFloat
+        @test mBoundary.metadata["criterionFallback"] === true
+        @test searchAicc(mBoundary) ≈ publicBoundary + Sarimax.FALLBACK_CRITERION_PENALTY
+        @test searchAicc(mBoundary) > searchAicc(m)
     end
 
     @testset "caminhos de busca antes mortos: grid e stepwiseNaive" begin

--- a/test/exact_likelihood.jl
+++ b/test/exact_likelihood.jl
@@ -1,0 +1,156 @@
+# Testes da verossimilhanca gaussiana exata (src/exact_likelihood.jl).
+#
+# A referencia independente e a MVN completa: para z ~ N(0, sigma^2 * Gamma) com
+# Gamma_{ij} = gamma(|i-j|) e sigma^2 concentrado,
+#
+#     l = -(n/2) (log(2 pi sigma2) + 1) - (1/2) logdet(Gamma),
+#     sigma2 = z' Gamma^{-1} z / n.
+#
+# E exatamente a quantidade que Durbin-Levinson calcula em O(n^2), obtida aqui por
+# algebra linear densa — nenhuma linha de codigo compartilhada com a implementacao.
+# (LinearAlgebra vem qualificado via Sarimax para nao exigir declaracao no test target.)
+referenceExactLoglike(z::Vector{Float64}, γ::Vector{Float64}) = begin
+    LA = Sarimax.LinearAlgebra
+    n = length(z)
+    Γ = [γ[abs(i - j)+1] for i = 1:n, j = 1:n]
+    σ² = LA.dot(z, Γ \ z) / n
+    -(n / 2) * (log(2π * σ²) + 1) - LA.logdet(Γ) / 2
+end
+
+@testset "exact likelihood" begin
+    rng = MersenneTwister(0x5A71)
+
+    @testset "expandMultiplicativePolynomial" begin
+        # (1 - 0.5B)(1 - 0.3B^12) = 1 - 0.5B - 0.3B^12 + 0.15B^13  (convencao AR)
+        ar = Sarimax.expandMultiplicativePolynomial([0.5], [0.3], 12; negate = true)
+        @test length(ar) == 13
+        @test ar[1] ≈ 0.5
+        @test ar[12] ≈ 0.3
+        @test ar[13] ≈ -0.15
+        @test all(iszero, ar[2:11])
+        # (1 + 0.5B)(1 + 0.3B^12): lado MA, produto cruzado com sinal positivo
+        ma = Sarimax.expandMultiplicativePolynomial([0.5], [0.3], 12; negate = false)
+        @test ma[13] ≈ 0.15
+        # casos degenerados
+        @test isempty(Sarimax.expandMultiplicativePolynomial(Float64[], Float64[], 12))
+        @test Sarimax.expandMultiplicativePolynomial([0.7], Float64[], 12) ≈ [0.7]
+    end
+
+    @testset "psi weights: sem colisao e base correta" begin
+        # ruido branco: psi_k = 0 para k >= 1, psi_0 = 1
+        @test Sarimax.psiWeights(Float64[], Float64[], 5) == zeros(5)
+        @test Sarimax.psiWeightsFromZero(Float64[], Float64[], 5) == [1.0; zeros(5)]
+        # AR(1): psi_k = phi^k
+        @test Sarimax.psiWeights([0.5], Float64[], 4) ≈ [0.5, 0.25, 0.125, 0.0625]
+        @test Sarimax.psiWeightsFromZero([0.5], Float64[], 4) ≈ [1.0, 0.5, 0.25, 0.125, 0.0625]
+        # a variancia de previsao de um ARMA(0,0) ajustado e constante = sigma^2
+        # (o bug historico de sobrescrita do psiWeights dava [1,2,2,2] * sigma^2)
+        yWN = TimeArray(
+            collect(Date(2000, 1, 1):Month(1):Date(2004, 12, 1)),
+            randn(rng, 60),
+        )
+        mWN = SARIMA(yWN, 0, 0, 0; allowMean = false)
+        fit!(mWN)
+        fe = Sarimax.forecastErrors(mWN, 4)
+        @test all(v -> isapprox(v, fe[1]; rtol = 1e-8), fe)
+    end
+
+    @testset "ruido branco: forma fechada" begin
+        z = randn(rng, 40)
+        n = length(z)
+        σ² = sum(abs2, z) / n
+        expected = -(n / 2) * (log(2π * σ²) + 1)
+        @test Sarimax.exactGaussianLogLikelihood(z, Float64[], Float64[]) ≈ expected
+    end
+
+    @testset "AR(1): forma fechada" begin
+        φ = 0.6
+        z = randn(rng, 50)
+        n = length(z)
+        # v_1 = 1/(1-phi^2), v_t = 1 (t >= 2); e_1 = z_1, e_t = z_t - phi z_{t-1}
+        σ² = ((1 - φ^2) * z[1]^2 + sum((z[t] - φ * z[t-1])^2 for t = 2:n)) / n
+        expected = -(n / 2) * (log(2π * σ²) + 1) - log(1 / (1 - φ^2)) / 2
+        @test Sarimax.exactGaussianLogLikelihood(z, [φ], Float64[]) ≈ expected
+    end
+
+    @testset "MA(1), ARMA(1,1) e sazonal: contra a MVN densa" begin
+        for (ar, ma) in (
+            (Float64[], [0.4]),                                  # MA(1)
+            ([0.5], [-0.3]),                                     # ARMA(1,1)
+            (
+                Sarimax.expandMultiplicativePolynomial([0.4], [0.3], 4; negate = true),
+                Sarimax.expandMultiplicativePolynomial([-0.2], [0.25], 4; negate = false),
+            ),                                                   # SARMA(1,1)(1,1)_4 expandido
+        )
+            z = randn(rng, 30)
+            γfull = Sarimax.theoreticalACF(ar, ma, length(z))
+            @test !isnothing(γfull)
+            @test Sarimax.exactGaussianLogLikelihood(z, ar, ma) ≈
+                  referenceExactLoglike(z, γfull) rtol = 1e-10
+        end
+    end
+
+    @testset "recusa principiada perto da fronteira" begin
+        # AR(1) com raiz quase unitaria: a cauda dos psi nao decai dentro da truncagem
+        # e a resposta certa e `nothing`, nunca um numero silenciosamente errado.
+        @test isnothing(Sarimax.theoreticalACF([0.99999], Float64[], 50))
+        @test isnothing(Sarimax.exactGaussianLogLikelihood(randn(rng, 50), [0.99999], Float64[]))
+        # ponto explosivo
+        @test isnothing(Sarimax.exactGaussianLogLikelihood(randn(rng, 50), [1.5], Float64[]))
+        # serie vazia
+        @test isnothing(Sarimax.exactGaussianLogLikelihood(Float64[], [0.5], Float64[]))
+        # modelo nao ajustado
+        yShort = TimeArray(collect(Date(2020, 1, 1):Month(1):Date(2021, 12, 1)), randn(rng, 24))
+        @test isnothing(Sarimax.exactLoglike(SARIMA(yShort, 1, 0, 0)))
+    end
+
+    @testset "exactLoglike do modelo ajustado bate com a avaliacao direta" begin
+        y = TimeArray(collect(Date(2000, 1, 1):Month(1):Date(2006, 12, 1)), randn(rng, 84))
+        m = SARIMA(y, 1, 0, 1; allowMean = false)
+        fit!(m)
+        ll = Sarimax.exactLoglike(m)
+        if !isnothing(ll)
+            z = Float64.(values(m.y))
+            @test ll ≈ Sarimax.exactGaussianLogLikelihood(z, [m.ϕ...], [m.θ...])
+        end
+    end
+
+    @testset "n do AICc casa com a amostra da verossimilhanca [defeito conhecido]" begin
+        # `aicc` corrige com n = length(observedResiduals) = T - lb + 1, mas a
+        # verossimilhanca exata que entra no criterio e avaliada sobre os T pontos da
+        # serie diferenciada. A correcao deveria usar o n da verossimilhanca usada.
+        y = TimeArray(collect(Date(2000, 1, 1):Month(1):Date(2006, 12, 1)), randn(rng, 84))
+        m = SARIMA(y, 2, 0, 0; allowMean = false)
+        fit!(m)  # :zeroed => residualLags = p = 2 => lb = 3
+        if !isnothing(Sarimax.exactLoglike(m))   # criterio esta no caminho exato
+            T = length(values(m.y))
+            nRes = length(Sarimax.observedResiduals(m))
+            @test nRes < T   # premissa do teste: a truncagem existe de fato
+            K = Sarimax.get_hyperparameters_number(m)
+            correctionOn(n) = (2K^2 + 2K) / (n - K - 1)
+            @test aicc(m) ≈ aic(m) + correctionOn(nRes)          # comportamento atual
+            @test_broken aicc(m) ≈ aic(m) + correctionOn(T)       # comportamento correto
+        end
+    end
+
+    @testset "caminhos de busca antes mortos: grid e stepwiseNaive" begin
+        yAuto = TimeArray(
+            collect(Date(2000, 1, 1):Month(1):Date(2004, 12, 1)),
+            0.7 .* sin.(2π .* (1:60) ./ 12) .+ randn(rng, 60) .* 0.5,
+        )
+        for method in ("grid", "stepwiseNaive")
+            m = auto(
+                yAuto;
+                seasonality = 1,
+                d = 0,
+                D = 0,
+                maxp = 1,
+                maxq = 1,
+                maxP = 0,
+                maxQ = 0,
+                searchMethod = method,
+            )
+            @test Sarimax.isFitted(m)
+        end
+    end
+end

--- a/test/exact_likelihood.jl
+++ b/test/exact_likelihood.jl
@@ -137,6 +137,17 @@ end
         end
     end
 
+    @testset "criterionSampleSize: aritmetica == differentiate" begin
+        # `criterionSampleSize` usa `n - d - D*s` em vez de alocar a serie diferenciada.
+        # A equivalencia tem que valer para toda combinacao de ordens de diferenciacao.
+        yLong = TimeArray(collect(Date(2000, 1, 1):Month(1):Date(2010, 12, 1)), randn(rng, 132))
+        for (d, D, s) in ((0, 0, 1), (1, 0, 1), (2, 0, 1), (0, 1, 12), (1, 1, 12), (2, 1, 12), (1, 2, 4))
+            m = SARIMA(yLong, 1, d, 0; seasonality = s, D = D)
+            @test Sarimax.criterionSampleSize(m) ==
+                  length(values(differentiate(yLong, d, D, s)))
+        end
+    end
+
     @testset "selecao: recuo CSS nunca vence candidato com exata" begin
         # O criterio de BUSCA (getInformationCriteriaFunction) penaliza candidatos cujo
         # criterio veio do recuo; os acessores publicos nao mudam.

--- a/test/fit.jl
+++ b/test/fit.jl
@@ -54,16 +54,23 @@
         airPassengersLog = log.(airPassengers)
         testModel = SARIMA(airPassengersLog, 3, 0, 1; seasonality = 12, P = 1, D = 1, Q = 1)
         fit!(testModel)
-        # CSS log-likelihood with full Gaussian constants, multiplicative
-        # seasonal form (v0.3 default): aic = 2K - 2ℓ, K counts all declared
-        # parameters (+σ²)
-        @test aic(testModel) ≈ -479.7726772190683 atol = 1e-3
-        @test aicc(testModel) ≈ -478.9155343619255 atol = 1e-3
-        @test bic(testModel) ≈ -454.3634793584777 atol = 1e-3
+        # Criteria are scored with `criterionLoglike`: the EXACT Gaussian log-likelihood
+        # when computable (the case here), CSS fallback otherwise. `K = ncoef + 1` counts
+        # all declared parameters (+σ²), and the small-sample correction / BIC factor use
+        # the sample size of the likelihood actually used (`T` on the exact path — NOT
+        # `length(observedResiduals)`, which discounts the CSS conditioning).
         K = get_hyperparameters_number(testModel)
         @test K == 8
-        @test aic(testModel) ≈ 2 * K - 2 * loglike(testModel) atol = 1e-10
-        @test bic(testModel) ≈ K * log(length(testModel.ϵ)) - 2 * loglike(testModel) atol = 1e-10
+        ll, n, usedExact = Sarimax.criterionLoglikeAndN(testModel)
+        @test usedExact
+        @test n == length(values(differentiate(airPassengersLog, 0, 1, 12)))
+        @test aic(testModel) ≈ 2 * K - 2 * ll atol = 1e-10
+        @test aicc(testModel) ≈ aic(testModel) + (2 * K * K + 2 * K) / (n - K - 1) atol = 1e-10
+        @test bic(testModel) ≈ K * log(n) - 2 * ll atol = 1e-10
+        # the exact likelihood is never below the CSS one evaluated at the same point on
+        # fewer observations by more than the determinant term; what matters here is that
+        # the public accessors and the criterion core agree with each other
+        @test loglike(testModel) ≉ ll  # CSS accessor and exact criterion are distinct quantities
     end
 
 

--- a/test/models/sarima_auto.jl
+++ b/test/models/sarima_auto.jl
@@ -131,11 +131,14 @@
         @test model.Q == 1
         @test model.d == 1
         @test model.D == 1
-        # Valor repinado em 2026-08: o AICc passou a ser calculado sobre a verossimilhança
-        # gaussiana EXATA (`criterionLoglike`) em vez da CSS plug-in, e `K = ncoef + 1` (sem
-        # `nPresampleFree`), casando com o `forecast::Arima`. A ORDEM selecionada não mudou —
+        # Valor repinado em 2026-08 (duas vezes): (1) o AICc passou a ser calculado sobre a
+        # verossimilhança gaussiana EXATA (`criterionLoglike`) em vez da CSS plug-in, e
+        # `K = ncoef + 1` (sem `nPresampleFree`), casando com o `forecast::Arima`;
+        # (2) a correção de amostra pequena passou a usar o `n` da verossimilhança usada
+        # (`T` no caminho exato), não o `length(observedResiduals)` condicionado — era uma
+        # penalidade extra de ~0.115 aqui. A ORDEM selecionada não mudou em nenhum repin —
         # só o valor do critério, como tem que ser numa troca de escala de verossimilhança.
-        @test aicc(model) ≈ 521.9660727530161 atol = 1e-6
+        @test aicc(model) ≈ 521.8508218836669 atol = 1e-6
     end
 
     @testset "parallel candidate fitting (smoke)" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -56,5 +56,7 @@ using JSON
 
     include("missing_data.jl")
 
+    include("exact_likelihood.jl")
+
     include("aqua.jl")
 end


### PR DESCRIPTION
Three coupled defects in the exact-likelihood criteria introduced by 6d9f03a, plus the tests that were missing to catch them.

## The core problem: the two likelihoods do not live on the same sample

- **Exact** (`exact_likelihood.jl:137`): `n = length(z)`, the whole differenced series — call it `T`.
- **CSS** (`utils.jl:443-444`): `n = length(observedResiduals(model))`, and the residual vector is truncated at `lb` (`sarima.jl:1462`).

In `auto`, every candidate gets `minConditioningObs = searchLb = max(maxp + s·maxP, maxq + s·maxQ)`, which is **29** at the monthly defaults. On a ~100-point series with `d = D = 1` the exact likelihood scores 87 observations and the CSS one scores 58 — a difference on the order of **80 AICc units**, where selection decisions are settled at ~2.

### The distortion's *direction* flips with the data scale

The gap is approximately `((lb-1)/2)·log(2πe·σ̂²) + Σlog(v_t)/2`, so the first term changes sign at `σ̂² = 1/(2πe) ≈ 0.0586`:

| AirPassengers | σ̂² | `log(2πe·σ̂²)` | fallback candidate |
|---|---|---|---|
| levels | 0.954 | +2.79 | **rewarded** |
| logs | 0.0044 | −2.59 | **penalized** |

Same series, same model, opposite sign — decided by whether the user log-transformed. What triggers the fallback is the ψ tail failing to decay (`exact_likelihood.jl:104`) or the recursion losing positive definiteness (`:154`, `:156`), i.e. **roots near the boundary**. So near-boundary candidates are scored on a different instrument than the rest, and whether that instrument flatters or punishes them is a property of the input units rather than of the model.

That is worse than a consistent bias would be: it cannot be reasoned about or corrected for, and it makes selection depend on a transformation that is supposed to be statistically innocuous.

## What this PR changes

**1. `criterionLoglike` no longer swallows exceptions.** `exactLoglike`'s contract is already `nothing`-on-refusal, so the blanket `try/catch` could only mask bugs — `MethodError`, `UndefVarError`, the class that has bitten this file before — and made the measured fallback rate uninterpretable: it could not separate a principled refusal from a masked exception. Model types without `exactLoglike` fall back via `applicable`. The fallback is now recorded in `model.metadata["criterionFallback"]` so its rate is measurable.

**2. AICc/BIC use the sample size of the likelihood they actually score.** The correction term and the `log(n)` factor used the CSS-conditioned count even on the exact path. That is an undocumented size penalty growing with `K` (+0.60 at `K = 6`, +1.79 at `K = 10` for `T = 87`) that `forecast::Arima` does not have — a parity gap in exactly the place where parity is the stated prerequisite. The comment at `sarima.jl:718-720` asserting `length(observedResiduals)` already equalled R's `n* = n - d - D·m` was simply wrong; corrected.

**3. Selection penalizes fallback-scored candidates.** `getInformationCriteriaFunction` now wraps the criterion so a candidate scored by the fallback can never outrank one scored by the exact likelihood — the two-tier order is analogous to `forecast::myarima` returning `Inf` on a non-finite likelihood. Additive rather than `Inf` so the search is never left without a selection when the exact likelihood fails on every candidate. **The public `aic`/`aicc`/`bic` accessors are unchanged.**

## Tests

`test/exact_likelihood.jl` (new): analytic closed forms (white noise, AR(1)), a dense-MVN `logdet` cross-check that shares no code with the Durbin-Levinson path, multiplicative polynomial expansion, a regression test for the ψ-weight name collision, principled-refusal cases, the two-tier selection order, and smoke tests for `searchMethod = "grid"` and `"stepwiseNaive"` — both of which had never been executed.

Two things worth flagging:

- **`dev` already had 5 failing tests** in `test/fit.jl`, still pinned to the pre-6d9f03a CSS criteria. Rewritten for the current semantics.
- The `sarima_auto.jl` AICc pin moved by −0.115. That is exactly the size penalty removed at `K = 7`; **the selected order is unchanged**.

## Performance

No speedup is claimed. `criterionSampleSize` initially allocated the differenced series just to measure it, costing ~7.5µs per criterion evaluation; computing `n - d - D·s` restores parity with `dev` (paired measurement, same session, median of 7 batches of 3000 `aicc` calls: **147.5µs** here vs **146.4µs** on `dev` — within noise). The formula's equivalence is pinned across seven `d`/`D`/`s` combinations.

Also measured, refuting a suspected bottleneck: `exactLoglike` costs 0.26ms against ~32ms for a `fit!` at `n = 300`, and is evaluated once per candidate (cached in `visitedModels`). An adaptive ψ-tail cutoff in `theoreticalACF` would recover ~2% at most — not implemented.

## Verification

Full suite green on Julia 1.12.3: **917 passed, 0 failed**, 1 pre-existing `@test_broken`. No public signature changed.

## Still open

The fallback *rate* and the selection effect at scale cannot be measured without `ForecastTester` (M4 monthly, the R baselines, `dbg_valida_exata.jl`), which is not on my machine. Issues 2, 5 and 7 from the review notes depend on those numbers and are untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbxTK3m65HMy2rjETjVGZ
