### PR TITLE
Guardrails: count K by the fitting objective, warn on silent degradation, document maxOrder and the quasi-AIC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - Unreleased
 
 ### Fixed
+- **A `lambda` the estimation ignores no longer moves the information criteria.** The sparse
+  parameter count was triggered by the *presence* of `lambda`/`alpha` on the model rather
+  than by the objective that actually fitted it. Measured: with fixed coefficients
+  `[0.5, 0.0, 0.0]` and `objectiveFunction = "mse"`, passing `lambda = 1.0` left the
+  coefficients bit-identical but took `K` from 4 to 2 and the AICc from 190.9058 to
+  186.3890 — 4.5 units, on a scale where decisions turn at ~2. The count now keys off
+  `model.metadata["objectiveFunction"]`. `elastic_net` keeps its sparse count at every
+  `alpha`; restricting it to the lasso case (`alpha = 1`), the only one with a
+  degrees-of-freedom result behind it, is a policy question and is left open.
+- **`objectiveFunction = "ridge"` now warns that it ignores `lambda`.** The shrinkage is
+  fixed at `sqrt(effective sample size)` in the objective; the argument was accepted,
+  stored and silently discarded (verified: `lambda` from 0.01 to 100 gives identical
+  coefficients to six decimals). Whether to honour it or reject it outright is left open —
+  accepting it silently was the one indefensible option.
+- **`objectiveFunction = "ml_exact"` now warns when it degrades to plain CSS**, i.e. when
+  the reflection parameterization is off (`stationary = false`) or there is no non-seasonal
+  AR part (`p = 0`). In those cases the user asked for an exact likelihood and got the
+  conditional one verbatim (verified: identical coefficients to `"mse"`). The partial
+  coverage on ARMA/seasonal models is documented scope and does not warn.
+
+### Documentation
+- `auto`'s `maxOrder` now documents that it applies to `searchMethod = "grid"` only. At the
+  monthly defaults the grid therefore reaches 96 of the 324 order combinations in the box
+  while the stepwise search reaches all 324 — the exhaustive method searches a smaller space
+  than the heuristic one and can lose to it. The stepwise behaviour is deliberate parity with
+  `forecast`; the surprise was that it went unstated.
+- `criterionLoglike` documents that the criteria are a **quasi-AIC**: the likelihood is
+  evaluated at the coefficients the user's objective produced, not at the Gaussian maximum,
+  with the measured size of the deficit and why a one-step Newton refinement does not close
+  it (the optimum sits on the invertibility boundary, where Le Cam equivalence fails).
+
 - **Criterion fallback no longer rewards boundary candidates.** When the exact
   Gaussian likelihood is not computable (roots at the boundary), the criterion falls
   back to the CSS likelihood — which is evaluated on the conditioned sample

--- a/src/fit.jl
+++ b/src/fit.jl
@@ -108,6 +108,17 @@ Sem `try/catch`: o contrato de `exactLoglike` ja e nothing-em-recusa, entao qual
 aqui e bug e deve subir — um `catch` largo mascararia exatamente a classe de erro
 (`MethodError`, `UndefVarError`) que ja mordeu este arquivo, e tornaria a taxa de recuo
 impossivel de interpretar. Tipos de modelo sem `exactLoglike` recuam via `applicable`.
+
+QUASI-AIC, NAO AIC. Esta verossimilhanca e avaliada nos coeficientes que o OBJETIVO DO USUARIO
+produziu (`mae`, `huber`, `CVaR`, ridge, ...), nao no maximo da gaussiana. Como estatistica de
+comparacao entre candidatos e legitima — a mesma funcao pontua todos —, mas nao e a
+verossimilhanca maximizada que a teoria do AIC supoe. Medido em ARMA(1,1) simulado, o deficit
+`2*(l(EMV) - l(ponto ajustado))` tem mediana 0,01 sob `mse` e sobe com o raio da raiz MA:
+mediana 0,98 e p90 7,03 com raiz em 0,98, isto e, ja na escala em que o AICc decide. Sob
+`ridge` a mediana vai a 1,79, porque o encolhimento afasta o ponto do maximo de proposito.
+Refinar por um passo de Newton NAO resolve: no regime que importa o otimo esta na fronteira de
+invertibilidade (theta_EMV empilha em 1), onde a equivalencia assintotica de Le Cam nao vale —
+medido, um passo fecha 6% do deficit e piora o valor em 40% dos casos.
 """
 function criterionLoglike(model::SarimaxModel)
     return first(criterionLoglikeAndN(model))

--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -700,7 +700,19 @@ of-freedom estimate for L1-type regularization (Zou, Hastie & Tibshirani, 2007).
 
 """
 function get_hyperparameters_number(model::SARIMAModel)
-    usesSparseCount = !isnothing(model.lambda) || !isnothing(model.alpha)
+    # Pelo OBJETIVO que ajustou o modelo, nao pela presenca de `lambda`/`alpha` nos campos.
+    # O gatilho antigo (`!isnothing(model.lambda) || !isnothing(model.alpha)`) fazia um
+    # parametro que a estimacao IGNORA mexer no criterio: com coeficientes fixos
+    # `[0.5, 0.0, 0.0]`, passar `lambda = 1.0` num ajuste `mse` deixava os coeficientes
+    # bit-a-bit identicos mas levava K de 4 para 2 e o AICc de 190.9058 para 186.3890 —
+    # 4,5 unidades num limiar de decisao de ~2.
+    #
+    # ESCOPO desta correcao: mata o gatilho vazio e nada mais. A contagem de nao-nulos segue
+    # valendo para `elastic_net` em qualquer `alpha`, como hoje. Restringi-la ao lasso
+    # (`alpha = 1`), que e o unico caso com respaldo teorico (Zou-Hastie-Tibshirani 2007 —
+    # sob ridge a contagem degenera para a nominal, porque ridge encolhe e nao zera), e
+    # mudanca de politica, nao correcao de defeito.
+    usesSparseCount = get(model.metadata, "objectiveFunction", "") == "elastic_net"
     if isFitted(model) && usesSparseCount
         hyperparametersNumber = 1
         fields = [:c, :trend, :ϕ, :θ, :Φ, :Θ, :exogCoefficients]
@@ -1061,6 +1073,20 @@ function fit!(
     isnothing(alpha) || (model.alpha = alpha)
     model.metadata["seasonalForm"] = String(seasonalForm)
     model.metadata["initialization"] = String(initialization)
+    # Registrado porque a CONTAGEM DE PARAMETROS depende do objetivo que de fato ajustou o
+    # modelo, e nao da presenca dos campos `lambda`/`alpha` — ver `get_hyperparameters_number`.
+    model.metadata["objectiveFunction"] = objectiveFunction
+
+    # O objetivo `ridge` fixa `lambda = sqrt(nEff)` internamente (ver a definicao do objetivo)
+    # e IGNORA o argumento. Aceitar em silencio e o pior dos mundos: o usuario pensa estar
+    # controlando o encolhimento, o ajuste nao muda, e — antes da correcao do gatilho de
+    # `usesSparseCount` — o `lambda` ainda mexia no criterio. Honrar o argumento ou recusa-lo
+    # com erro sao decisoes de comportamento; avisar nao e.
+    if objectiveFunction == "ridge" && !isnothing(lambda)
+        @warn "objectiveFunction = \"ridge\" ignores `lambda`: the shrinkage is fixed at " *
+              "sqrt(effective sample size) by construction. The value passed has no effect " *
+              "on the fit." maxlog = 1
+    end
 
     # Telemetria de custo (atribuicao de performance). O orcamento de uma busca e
     # (nº de fits) x (custo por fit), e o custo por fit se divide em CONSTRUIR o problema
@@ -2030,6 +2056,21 @@ function objectiveFunctionDefinition!(
         # conjunto nao fatora assim, e o que se aplica e uma correcao parcial (so a parte
         # autorregressiva nao-sazonal); os demais residuos seguem em CSS.
         temK = haskey(object_dictionary(jumpModel), :κAR) && model.p > 0
+        # Sem `κAR` (isto e, `stationary = false`) ou sem parte AR (`p = 0`), a correcao dos
+        # valores iniciais nao tem por onde ser escrita e o objetivo vira CSS PURO — o usuario
+        # pediu verossimilhanca exata e recebe exatamente o `mse` condicionado, verificado:
+        # AR(2) com `stationary = false` produz coeficientes identicos ao `mse` (diferenca 0,0).
+        # Avisar so na degradacao TOTAL; a cobertura parcial em ARMA/sazonal e escopo declarado
+        # na documentacao acima, nao surpresa.
+        #
+        # Isto tambem e o alarme do lead de performance que propoe `stationary = false` como
+        # default de busca: se aquilo entrar, o `ml_exact` vira CSS silenciosamente.
+        if !temK || isnothing(yValues)
+            @warn "objectiveFunction = \"ml_exact\" degrades to plain CSS here: it needs " *
+                  "the reflection parameterization (`stationary = true`) and a non-seasonal " *
+                  "AR part (`p > 0`). Got " *
+                  "stationary=$(haskey(object_dictionary(jumpModel), :κAR)), p=$(model.p)." maxlog = 1
+        end
         if !temK || isnothing(yValues)
             @objective(jumpModel, Min, sum(jumpModel[:ϵ][t]^2 for t = lb:T))
         else
@@ -2784,7 +2825,15 @@ Automatically fits the best SARIMA model according to the specified parameters.
 - `maxP::Int`: The maximum autoregressive order for the seasonal part. Default is 2.
 - `maxD::Int`: The maximum integration order for the seasonal part. Default is 1.
 - `maxQ::Int`: The maximum moving average order for the seasonal part. Default is 2.
-- `maxOrder::Int`: The maximum order for the non-seasonal part. Default is 5.
+- `maxOrder::Int`: Cap on `p + q + P + Q`. Default is 5. **Applies to
+  `searchMethod = "grid"` only.** The stepwise searches deliberately run with the cap
+  disabled, to match `forecast`: there `max.order` lives inside `search.arima` (the
+  non-stepwise path), and since `auto.arima` defaults to stepwise, R routinely selects
+  orders whose sum exceeds 5. The consequence is that at the monthly defaults
+  (`maxp = maxq = 5`, `maxP = maxQ = 2`) the grid reaches 96 of the 324 order combinations
+  in the box while the stepwise search reaches all 324 — i.e. the exhaustive method
+  searches a *smaller* space than the heuristic one, and can lose to it. Raise `maxOrder`
+  (up to `maxp + maxq + maxP + maxQ`) to make `"grid"` genuinely exhaustive.
 - `informationCriteria::String`: The information criteria to be used for model selection. Options are "aic", "aicc", or "bic". Default is "aicc".
 - `allowMean::Union{Bool,Nothing}`: Whether to include a mean term in the model. Default is nothing.
 - `allowDrift::Union{Bool,Nothing}`: Whether to include a drift term in the model. Default is nothing.

--- a/test/objective_guardrails.jl
+++ b/test/objective_guardrails.jl
@@ -1,0 +1,78 @@
+# Guardas contra comportamento indefensavel em silencio.
+#
+# Nenhum destes testes fixa POLITICA (quanto encolher, quais graus de liberdade cobrar, que
+# espaco varrer) — todos fixam a ausencia de surpresa: parametro ignorado nao pode mexer no
+# criterio, e objetivo que degrada tem que avisar.
+@testset "guardas de objetivo e contagem de parametros" begin
+    rng = MersenneTwister(0x6A11)
+    dates(n) = collect(Date(2000, 1, 1):Month(1):Date(2000, 1, 1)+Month(n - 1))
+
+    @testset "lambda ignorado nao pode mexer no criterio" begin
+        # Reproducao do defeito: o gatilho da contagem esparsa era a PRESENCA de
+        # `lambda`/`alpha`, nao o objetivo usado. Com coeficientes fixos e objetivo `mse`
+        # (que ignora `lambda`), passar `lambda` mantinha o ajuste bit-a-bit identico mas
+        # levava K de 4 para 2 e o AICc de 190.9058 para 186.3890.
+        y = TimeArray(dates(60), randn(rng, 60))
+        semLambda = SARIMA(y; arCoefficients = [0.5, 0.0, 0.0], allowMean = false)
+        comLambda = SARIMA(y; arCoefficients = [0.5, 0.0, 0.0], allowMean = false, lambda = 1.0)
+        fit!(semLambda)
+        fit!(comLambda)
+
+        @test [semLambda.ϕ...] ≈ [comLambda.ϕ...] atol = 1e-12   # premissa: ajuste identico
+        @test get_hyperparameters_number(semLambda) == get_hyperparameters_number(comLambda)
+        @test aicc(semLambda) ≈ aicc(comLambda)
+        @test aic(semLambda) ≈ aic(comLambda)
+        @test bic(semLambda) ≈ bic(comLambda)
+        # `alpha` tem o mesmo gatilho e a mesma exigencia
+        comAlpha = SARIMA(y; arCoefficients = [0.5, 0.0, 0.0], allowMean = false, alpha = 0.5)
+        fit!(comAlpha)
+        @test aicc(comAlpha) ≈ aicc(semLambda)
+    end
+
+    @testset "elastic_net mantem a contagem esparsa" begin
+        # A correcao acima nao pode ter desligado a contagem esparsa de quem realmente
+        # regulariza. Restringi-la ao lasso (`alpha = 1`) e mudanca de politica, nao de defeito.
+        n = 150
+        y = TimeArray(
+            dates(n),
+            10 .+ 0.6 .* sin.(2π .* (1:n) ./ 12) .+ cumsum(randn(rng, n) .* 0.25),
+        )
+        m = SARIMA(y, 3, 1, 2; seasonality = 12, P = 1, D = 0, Q = 1, allowMean = false)
+        fit!(m; objectiveFunction = "elastic_net", alpha = 1.0)
+        nominal = m.p + m.q + m.P + m.Q + 1
+        coefs = vcat([m.ϕ...], [m.θ...], [m.Φ...], [m.Θ...])
+        @test any(c -> abs(c) <= 1e-5, coefs)              # premissa: houve zeragem
+        @test get_hyperparameters_number(m) < nominal
+        @test m.metadata["objectiveFunction"] == "elastic_net"
+    end
+
+    @testset "ridge avisa que ignora lambda" begin
+        n = 90
+        y = TimeArray(dates(n), 10 .+ cumsum(randn(rng, n) .* 0.3))
+        mk() = SARIMA(y, 2, 1, 1; allowMean = false)
+        @test_logs (:warn, r"ignores `lambda`") match_mode = :any fit!(
+            mk(); objectiveFunction = "ridge", alpha = 0.0, lambda = 1.0
+        )
+        # sem `lambda` nao ha o que avisar
+        @test_logs match_mode = :any fit!(mk(); objectiveFunction = "ridge", alpha = 0.0)
+    end
+
+    @testset "ml_exact avisa quando degrada por completo" begin
+        n = 90
+        y = TimeArray(dates(n), 10 .+ cumsum(randn(rng, n) .* 0.3))
+        # sem a parametrizacao por reflexao o objetivo vira CSS puro
+        @test_logs (:warn, r"degrades to plain CSS") match_mode = :any fit!(
+            SARIMA(y, 2, 1, 0; allowMean = false); objectiveFunction = "ml_exact",
+            stationary = false,
+        )
+        # sem parte AR, idem
+        @test_logs (:warn, r"degrades to plain CSS") match_mode = :any fit!(
+            SARIMA(y, 0, 1, 1; allowMean = false); objectiveFunction = "ml_exact",
+        )
+        # negativo: AR puro com `stationary = true` e o caso suportado, nao avisa
+        @test_logs match_mode = :any fit!(
+            SARIMA(y, 2, 1, 0; allowMean = false); objectiveFunction = "ml_exact",
+            stationary = true,
+        )
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -58,5 +58,7 @@ using JSON
 
     include("exact_likelihood.jl")
 
+    include("objective_guardrails.jl")
+
     include("aqua.jl")
 end


### PR DESCRIPTION
Guardrails from the review of open questions 2, 5 and 7. Stacked on #10.

Everything here fixes behaviour that is **indefensible in silence**. Nothing here makes a policy choice — the list of what was deliberately *not* done is at the bottom, and it is yours.

## 1. A `lambda` the estimation ignores was moving the criterion by 4.5 AICc units

The sparse parameter count was triggered by `lambda`/`alpha` being **set on the model**, not by the objective that actually fitted it. Since `"mse"` ignores both:

```
fixed coefficients [0.5, 0.0, 0.0], objectiveFunction = "mse"

without lambda:  K = 4    aicc = 190.9058
with lambda=1.0: K = 2    aicc = 186.3890     Δ = -4.52
coefficients: bit-identical
```

4.5 units on a scale where decisions turn at ~2. The count now keys off `metadata["objectiveFunction"]`.

**Scope is the empty trigger and nothing else.** `elastic_net` keeps its sparse count at every `alpha`. Restricting it to the lasso case (`alpha = 1`) is the change with theory behind it — Zou-Hastie-Tibshirani (2007) gives the nonzero count as an unbiased df estimator for the lasso specifically; under **ridge** the count degenerates to the nominal one, since ridge shrinks without zeroing (measured: 0 of 7 coefficients below 1e-5, K = nominal = 8). That is your call, not a defect fix.

## 2. `"ridge"` warns that it ignores `lambda`

The objective fixes `λ = sqrt(effective sample size)` in code. The argument was accepted, stored, and discarded — verified with `lambda` from 0.01 to 100 giving identical coefficients to six decimals. Honouring it or rejecting it with an error are both behaviour changes and are left to you; accepting it silently was the one option with nothing to be said for it.

## 3. `"ml_exact"` warns when it degrades to plain CSS

When `stationary = false` or `p = 0` the correction has nothing to attach to and the objective becomes the conditional one verbatim — verified: `AR(2)` with `stationary = false` gives coefficients identical to `"mse"`. Only **full** degradation warns; the partial coverage on ARMA/seasonal models is documented scope.

This also arms a tripwire for the pending proposal to make `stationary = false` the search default: if that lands, `ml_exact` becomes CSS for everyone.

## 4. Documentation

**`maxOrder` applies to `searchMethod = "grid"` only.** At the monthly defaults the grid reaches **96 of the 324** order combinations in the box while the stepwise search reaches all 324 — the exhaustive method searches a *smaller* space than the heuristic one, and can lose to it:

```
stepwise = (3,0,0)(2,1,1)  sum=6  aicc = 49.03
grid     = (1,0,0)(2,1,1)  sum=4  aicc = 51.34   <- outside the grid's space
```

The stepwise behaviour is deliberate parity with `forecast` and is right. The surprise was that it went unstated, and that someone asking for an exhaustive search gets a 3× smaller one.

**`criterionLoglike` is documented as a quasi-AIC.** The likelihood is evaluated at the coefficients the user's objective produced, not at the Gaussian maximum. Measured deficit `2·(ℓ(MLE) − ℓ(fitted))` on simulated ARMA(1,1): median 0.01 under `mse`, but median 0.98 / p90 7.03 with an MA root at 0.98, and median 1.79 under `ridge`. It is driven by **MA root radius, not by high `q`** — ARMA(1,1) at θ=0.95 beats ARMA(1,3) at θ=0.5.

On the one-step Newton refinement you proposed for that deficit: **it does not work.** At θ=0.98 it closes 6% of the gap and makes the value *worse* in 40% of cases. The cause is structural, not numerical — `cond(H)` has median 4.0, but θ̂_ML piles up at 1.000, i.e. the optimum sits on the invertibility boundary, where Le Cam's interior-regularity condition fails. A full ML refit does reach it, at 3× a `fit!` against 0.5× for the one-step — the cheap thing does not work and the thing that works is affordable on finalists only. Details and the fork (re-score only vs adopt refined coefficients) are in the memo.

## Deliberately not done — these are yours

Honour-vs-error for ridge's `lambda`; lasso-only sparse counting; effective df for ridge/elastic net; aligning `maxOrder`'s default (changes selection → needs the OWA gate); any form of the Q2 ML refit, including behind a default-off flag; fallback-penalty variants; `stationary = false` as search default.

One open question the reproduction raised: it uses `keepProvidedCoefficients`, which makes it worth asking whether **provided fixed** coefficients should count in `K` at all — they were not estimated.

## Verification

Full suite green (943 passed). Selection gate: 30-series corpus, orders and AICc identical to the branch base — as expected, since these are warnings and an empty trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbxTK3m65HMy2rjETjVGZ
