### PR TITLE
Remove the right deterministic term in the exact likelihood (15.7% of M4 monthly affected)

### DIFF
--- a/src/exact_likelihood.jl
+++ b/src/exact_likelihood.jl
@@ -222,16 +222,36 @@ function exactLoglike(model::SARIMAModel)
     if !isnothing(model.c) && model.allowMean
         arSum = isempty(ar) ? zero(eltype(z)) : sum(ar)
         denom = 1 - arSum
+        # `denom = phi(1)*Phi(1)`, ja com o polinomio expandido. Quando ele vai a zero o
+        # processo tem raiz unitaria e a MEDIA NAO EXISTE — nenhum valor aqui esta certo.
+        # Cai-se em `model.c` por ser finito, nao por ser correto; e o candidato deveria ter
+        # sido rejeitado pela admissibilidade antes de chegar aqui.
+        if abs(denom) <= 1e-8
+            @warn "exactGaussianLogLikelihood: phi(1)*Phi(1) = $(denom) ~ 0 (raiz unitaria); " *
+                  "a media do processo nao existe e o nivel removido e apenas finito, nao correto."
+        end
         level = abs(denom) > 1e-8 ? model.c / denom : model.c
         z = z .- level
     end
     if !isnothing(model.trend) && model.allowDrift
+        # O fallback `fill(1.0, ...)` E EXATAMENTE O BUG que este commit corrige: subtrair o
+        # escalar em vez do regressor diferenciado. Se ele disparar em silencio, o defeito
+        # volta numa configuracao que ninguem testou e sem deixar rastro. Avisa.
         driftReg = try
             r = values(differentiate(
                     TimeArray(timestamp(model.y), collect(1.0:length(values(model.y)))),
                     model.d, model.D, s))
-            length(r) == length(z) ? Float64.(r) : fill(1.0, length(z))
-        catch
+            if length(r) == length(z)
+                Float64.(r)
+            else
+                @warn "exactGaussianLogLikelihood: regressor de drift diferenciado tem " *
+                      "comprimento $(length(r)), esperado $(length(z)); usando 1.0. " *
+                      "Com d=$(model.d), D=$(model.D), s=$s o termo deterministico fica errado."
+                fill(1.0, length(z))
+            end
+        catch e
+            @warn "exactGaussianLogLikelihood: falha ao diferenciar o regressor de drift " *
+                  "($(typeof(e))); usando 1.0, o que reintroduz o erro de escala."
             fill(1.0, length(z))
         end
         z = z .- model.trend .* driftReg


### PR DESCRIPTION
Two conversions were missing where `exactLoglike` removes the deterministic term. Both verified against `stats::arima(method = "ML")`, both found by running the full M4 monthly benchmark.

## The defects

**`model.c` is the regression constant, not the mean.** The level to remove is `mu = c / (1 - sum(ar))`. On M4 series 44895:

```
subtracting c   -> -2305.891
subtracting mu  -> -2304.253
R               -> -2304.253
```

An error of 1.64 log-likelihood = **3.3 AICc units**, on a scale where selections turn at ~2.

**`model.trend` multiplies the differenced time regressor** (`trend * driftValues[t]`), and that regressor is not 1 in general:

| d | D | regressor |
|---|---|---|
| 1 | 0 | 1 — the scalar happened to be right |
| **0** | **1** | **12** — off by a factor of `s` |
| 1 | 1 | 0 — drift not identifiable (already warned) |

## Incidence and impact, measured on the full 48,000 series

| | |
|---|---|
| series with a wrong likelihood driving their AICc | **7,529 (15.7%)** |
| OWA within those series | 0.8551 → **0.8464** |
| OWA over the whole benchmark | 0.9080 → **0.9065** |
| series whose selected order changes | 5.6% |

## Why the acceptance test missed it

`dbg_valida_exata.jl` centres the series and calls R with `include.mean = FALSE` — it exercises precisely the path where no deterministic term exists, so neither defect could ever surface there. That is not a criticism of the test's design for what it targets; it is a gap worth naming, because the same blind spot would hide any future regression in this code.

`test/deterministic_term.jl` covers it: the `c`-vs-`mu` identity on a series with known mean, the regressor values for `(d,D)` in `{(1,0),(0,1),(1,1)}`, and — importantly — an assertion that the scalar form is **not** equivalent, so the bug cannot silently return.

## Verification

Full suite green: 953 passed, 1 pre-existing `@test_broken`. Stacked on #11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxbxTK3m65HMy2rjETjVGZ
