### PR TITLE
:bug: Give the MA block its own determinant term

### DIFF
--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -2075,6 +2075,40 @@ function objectiveFunctionDefinition!(
                                       for j = 1:model.P])
             end
         end
+        # ---- bloco MA: o mesmo termo de determinante que o bloco AR ja tem ----
+        #
+        # O comentario acima afirma que somar os epsilon pre-amostrais a soma de quadrados basta
+        # ("Exato, e vale para MA e sazonal sem nenhuma maquina nova"). NAO basta: PERFILAR
+        # (minimizar) sobre os pre-amostrais nao e o mesmo que INTEGRA-los, e a diferenca e
+        # justamente o log-determinante. Sem ele o ponto ajustado nao e o de maxima
+        # verossimilhanca — medido contra `arima(method="ML")` do R, um MA(2) puro erra ~2e-3
+        # nos coeficientes, contra ~2e-5 de um AR(2) puro, que TEM o termo.
+        #
+        # A forma e a mesma do lado AR, com os coeficientes de reflexao do MA:
+        #     log|Omega| = -sum_j j*log(1 - kappa_j^2)
+        # Verificado contra o determinante da covariancia teorica de um MA(q) construida
+        # diretamente: erro ~1e-14 em theta = [0.5], [0.7], [0.4,0.2], [0.6,-0.3], [0.5,0.3,0.2].
+        # O bloco sazonal MA ganha a multiplicidade `s`, pela mesma fatoracao em cadeias de fase.
+        #
+        # So se aplica com `invertible = true`, que e quando os `kappa` do MA existem como
+        # variaveis de decisao; com a parametrizacao livre nao ha reflexao para usar.
+        # Os coeficientes de reflexao do MA NAO precisam da parametrizacao invertivel: a
+        # recursao inversa de Levinson-Durbin os produz a partir dos proprios `theta`, e o
+        # termo de determinante entao vale com `theta` LIVRE. Melhor ainda, ele torna a
+        # restricao dura redundante — `-sum_j j*log(1 - kappa_j^2)` diverge quando
+        # |kappa| -> 1, ou seja o proprio determinante e a barreira de invertibilidade, e
+        # repele a fronteira sem excluir nenhum ponto por decreto.
+        if model.q > 0
+            κMA = maToReflectionExpr(jumpModel[:θ], model.q)
+            isnothing(κMA) ||
+                (fator = fator * prod([(1 - κMA[j]^2)^(-j / T) for j = 1:model.q]))
+        end
+        if model.Q > 0
+            κSMA = maToReflectionExpr(jumpModel[:Θ], model.Q)
+            isnothing(κSMA) || (fator =
+                fator *
+                prod([(1 - κSMA[j]^2)^(-model.seasonality * j / T) for j = 1:model.Q]))
+        end
         @objective(jumpModel, Min, S * fator)
     elseif objectiveFunction == "mse"
         @objective(jumpModel, Min, sum(jumpModel[:ϵ] .^ 2))
@@ -5461,4 +5495,38 @@ function regularizationObjective(jumpModel::Model, model::SARIMAModel, tolerance
             (jumpModel[:α] * sum(weights .* auxVariables) + (1 - jumpModel[:α])/2 * sum(weights .* (parametersVectorExtended .^ 2)))
         )
     end
+end
+
+"""
+    maToReflectionExpr(θ, q)
+
+Coeficientes de reflexao do bloco MA como EXPRESSOES do modelo JuMP, pela recursao inversa de
+Levinson-Durbin — a mesma de [`maToReflection`](@ref), escrita para variaveis de decisao em vez
+de numeros. Existe para que o termo de log-determinante do bloco MA possa ser montado sem exigir
+`invertible = true`: a parametrizacao invertivel cria os `kappa` como variaveis limitadas, mas o
+que o determinante precisa e so do VALOR deles, e ele e uma funcao racional dos `theta`.
+
+Devolve `nothing` quando a ordem e zero. As divisoes por `1 - kappa^2` sao os mesmos
+denominadores da versao numerica; nao ha protecao contra zero aqui porque o proprio termo de
+determinante diverge la, o que e o comportamento desejado — ele repele a fronteira em vez de
+precisar de uma restricao que a exclua.
+"""
+function maToReflectionExpr(θ, q::Int)
+    q == 0 && return nothing
+    a = Any[θ[i] for i = 1:q]
+    κ = Vector{Any}(undef, q)
+    for m = q:-1:1
+        κ[m] = a[m]
+        if m > 1
+            d = 1 - κ[m]^2
+            aprev = Vector{Any}(undef, m - 1)
+            for i = 1:(m-1)
+                aprev[i] = (a[i] - κ[m] * a[m-i]) / d
+            end
+            for i = 1:(m-1)
+                a[i] = aprev[i]
+            end
+        end
+    end
+    κ
 end

--- a/test/exact_ml_determinant.jl
+++ b/test/exact_ml_determinant.jl
@@ -36,3 +36,13 @@
         @test abs(conjunto - soma) > 0.1
     end
 end
+
+@testset "MA determinant does not require the invertible parameterisation" begin
+    # A recursao inversa de Levinson-Durbin produz os `kappa` a partir dos proprios `theta`,
+    # entao o termo vale com `theta` LIVRE. E ele proprio e a barreira: diverge em |kappa| -> 1.
+    for θ in ([0.5], [0.4, 0.2], [0.6, -0.3])
+        κ = Sarimax.maToReflection(θ)
+        expr = Sarimax.maToReflectionExpr(θ, length(θ))
+        @test isapprox(Float64.(expr), κ; atol = 1e-12)
+    end
+end


### PR DESCRIPTION
Stacked on #16 (the exponent fix), since the two share the same `fator` expression.

## The defect

The `:penalized` comment states that adding the pre-sample innovations to the sum of squares is *"exato, e vale para MA e sazonal sem nenhuma maquina nova"*.

It is not. **Profiling** (minimising) over the initial values is not **integrating** them out, and the difference is a log-determinant — which the AR block has (the Levinson `fator`) and the MA block did not.

Measured against `arima(method = "ML")`:

| block | median coefficient error |
|---|---|
| pure AR(2) | 2.2e-5 (inside the documented 3e-5 precedent) |
| **pure MA(2)** | **2.1e-3** |

## The missing form

The same one the AR block already uses, with the MA reflection coefficients:

    log|Ω| = -Σ_j j·log(1 - κ_j²)

Verified against the determinant of a directly-constructed theoretical MA covariance — error **~1e-14** for `θ ∈ {[0.5], [0.7], [0.4,0.2], [0.6,-0.3], [0.5,0.3,0.2]}`. With the term, pure MA(2) lands at **1.5e-5**.

## It does not require `invertible = true`

The inverse Levinson-Durbin recursion produces the reflection coefficients from the **free** `θ`, so the term applies under the unconstrained parameterisation. Better: it diverges as `|κ| → 1`, so **the determinant is the invertibility barrier** — it repels the boundary instead of excluding it by decree, which is strictly less restrictive than a hard constraint.

`maToReflectionExpr` deliberately omits the numeric guard on `1 - κ²` that `maToReflection` carries: the determinant already diverges there, and that divergence is the desired behaviour.

## Scope, stated rather than assumed

This makes the **pure** blocks exact. For mixed ARMA the joint initial block does not factor, and the approximation there is unchanged — measured at **1.6e-1** median coefficient error for ARMA(2,1) against R's exact ML, versus 2e-5 for the pure blocks (max 1.17; 7 of 24 configurations above 0.1).

That asymmetry is a real consequence, not a footnote: the criterion now compares pure candidates on one footing and mixed ones on another. It is recorded in `test/exact_ml_determinant.jl` so the contrary assumption cannot creep back.

**Rectification (added after the first version of this description).** The 1.6e-1 figure above is an *optimisation* result and conflates two channels: the joint initial block not factoring (formulation), and the fit not reaching the global optimum (convergence). Evaluating the exact likelihood at fixed coefficients, R's ML point scores higher than ours in **8 of 10** mixed configurations, and different starting points land in visibly different basins — so a substantial part of that gap is convergence, not formulation.

The clean formulation fact, which involves no optimiser at all, is separate and stands: building Ω directly from the theoretical autocovariance at **fixed** coefficients, `log|Ω_ARMA|` differs from the sum of the two block formulas by **0.30 to 0.86** across five configurations. That is what "the joint block does not factor" means here, and it is what the regression test pins.

The honest statement of the consequence is therefore weaker than the first version claimed: mixed candidates are systematically mis-scored relative to pure ones.

**The decomposition has since been run, and both channels are confirmed.** With a start set named a priori (zero, Yule-Walker, CSS fit, and R's ML point as a diagnostic-only oracle bound):

| reading | result |
|---|---|
| coefficient distance to R's Φ | zero-only **0.2443** → multistart **0.0719** |
| exact loglik at the multistart's best point | **R still wins 7 of 10** (was 8/10) |

Convergence closes roughly 70% of the coefficient distance; formulation accounts for the residue. The unambiguous anchor is the oracle bound on one replicate: starting **from R's ML point**, the optimiser walks away, to a *worse* exact loglik (−278.41 versus −277.59 from zero). The optimum of this criterion is genuinely elsewhere, and no initialisation cures that.

Side finding, with the hypothesis labelled as such: the Yule-Walker seed produced results identical to a zero start in 10 of 10 configurations — inert. **Unmeasured hypothesis:** the warm start seeds the blocks that have reflection variables, and under `invertible = false` the MA coefficients have none, so the seed never reaches them. Flagged as a latent limitation rather than diagnosed.

## On M4 impact

Measured, but deliberately not the headline of this PR — the exactness verifications above are referenced against theory and stand on their own. For the record, on a pinned configuration over the full 48,000 monthly series the term improves aggregate OWA, with the improvement concentrated in the tail, driven by selection rather than estimation, and with two differencing classes regressing. Those numbers, with their confidence intervals and caveats, belong in the measurement report rather than here.

Full test suite green (962 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Xg2Dbck1PP1fKFp8kzgU8

