### PR TITLE
Declare the exogenous semantics: exogDynamics kwarg (ARMAX vs regression with ARIMA errors)

### DIFF
--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -889,6 +889,11 @@ function fit!(
     minConditioningObs::Int = 0,
     seasonalForm::Symbol = :multiplicative,
     initialization::Symbol = :zeroed,
+    # Semantica do bloco exogeno. Ver `arAcc` na construcao do modelo para as duas
+    # equacoes. O default `:armax` preserva o comportamento historico e o resultado
+    # numerico de todo caller existente; a virada de default e mudanca de release
+    # breaking, nao de kwarg.
+    exogDynamics::Symbol = :armax,
     # Default do R: `stats::arima` com `transform.pars = TRUE` parametriza o AR por `tanh`,
     # isto e, estacionario POR CONSTRUCAO num dominio aberto. O MA fica livre (ver
     # `invertible`), que e a outra metade do comportamento do R.
@@ -901,6 +906,11 @@ function fit!(
     multistart::Bool = false,
 )
     @assert 0.0 < cvarLevel < 1.0 "cvarLevel must lie strictly between 0 and 1."
+    exogDynamics in (:armax, :regression_errors) || throw(
+        ArgumentError(
+            "exogDynamics must be :armax or :regression_errors, got $(exogDynamics)",
+        ),
+    )
     # Two-phase warm-start orchestration: when a stationarity/invertibility-by-
     # construction fit is requested with `warmStartFromBox`, first solve the cheap
     # unconstrained (box) problem, then solve the constrained one warm-started from it
@@ -1164,6 +1174,7 @@ function fit!(
     isnothing(lambda) || (model.lambda = lambda)
     isnothing(alpha) || (model.alpha = alpha)
     model.metadata["seasonalForm"] = String(seasonalForm)
+    model.metadata["exogDynamics"] = String(exogDynamics)
     model.metadata["initialization"] = String(initialization)
     # Registrado porque a CONTAGEM DE PARAMETROS depende do objetivo que de fato ajustou o
     # modelo, e nao da presenca dos campos `lambda`/`alpha` — ver `get_hyperparameters_number`.
@@ -1397,6 +1408,38 @@ function fit!(
     else
         yAcc = OffsetArrays.OffsetVector(Any[yData...], 0)
     end
+
+    # SEMANTICA DO BLOCO EXOGENO. Duas equacoes distintas, ambas na literatura, e a
+    # escolha entre elas nao e detalhe de implementacao (Hyndman, "The ARIMAX model
+    # muddle", 2010):
+    #
+    #   :armax               phi(B) Phi(B^s) y_t = X_t'b + theta(B) Theta(B^s) e_t
+    #   :regression_errors   y_t = X_t'b + eta_t ,
+    #                        phi(B) Phi(B^s) eta_t = theta(B) Theta(B^s) e_t
+    #
+    # As duas coincidem SSE o polinomio AR (regular e sazonal) e unitario e nao ha
+    # diferenciacao. Fora dessa classe, b tem interpretacoes diferentes: sob :armax e
+    # multiplicador de impacto (condicional aos y passados), sob :regression_errors e o
+    # efeito marginal usual de regressao. `forecast::Arima(xreg=)` implementa a segunda,
+    # e por isso uma comparacao entre os dois pacotes fora dessa classe compara modelos
+    # diferentes -- medido em delta log(RMSE) de +-0,40 num DGP com T=180.
+    #
+    # A implementacao e uma substituicao so: os termos AR passam a operar sobre
+    # eta_t = y_t - X_t'b em vez de y_t. Os valores pre-amostrais livres ja representam
+    # eta diretamente (nao existe X antes do inicio da amostra), logo indices <= 0 passam
+    # intactos. O produto b*phi torna a expressao bilinear; o objetivo CSS ja e
+    # nao-convexo pelos termos MA, entao isso nao muda a classe do problema.
+    arAcc = if nExog == 0 || exogDynamics === :armax
+        yAcc
+    else
+        OffsetArrays.OffsetVector(
+            Any[
+                t <= 0 ? yAcc[t] :
+                yAcc[t] - sum(β[j] * exogValues[t, j] for j = 1:nExog) for t = yLo:T
+            ],
+            yLo - 1,
+        )
+    end
     # Free pre-sample values are penalized as parameters in the information criteria:
     # the ULS approximation leaves them unpenalized, which lets high-seasonal-order
     # candidates absorb s*P backcast degrees of freedom for free (overfit).
@@ -1487,15 +1530,15 @@ function fit!(
             c +
             trend * driftValues[t] +
             sum(β[i] * exogValues[t, i] for i = 1:nExog) +
-            sum(ϕ[i] * yAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
+            sum(ϕ[i] * arAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
             sum(θ[j] * epsAcc[t-j] for j = 1:model.q if (t - j >= epsLo)) +
             sum(
-                Φ[k] * yAcc[t-(model.seasonality*k)] for
+                Φ[k] * arAcc[t-(model.seasonality*k)] for
                 k = 1:model.P if (t - (model.seasonality * k) >= yLo)
             ) +
             sum(Θ[w] * epsAcc[t-(model.seasonality*w)] for w = 1:model.Q if (t - (model.seasonality * w) >= epsLo)) -
             sum(
-                ϕ[i] * Φ[k] * yAcc[t-i-(model.seasonality*k)] for
+                ϕ[i] * Φ[k] * arAcc[t-i-(model.seasonality*k)] for
                 i = 1:model.p, k = 1:model.P if (t - i - (model.seasonality * k) >= yLo)
             ) +
             sum(
@@ -1510,10 +1553,10 @@ function fit!(
             c +
             trend * driftValues[t] +
             sum(β[i] * exogValues[t, i] for i = 1:nExog) +
-            sum(ϕ[i] * yAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
+            sum(ϕ[i] * arAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
             sum(θ[j] * epsAcc[t-j] for j = 1:model.q if (t - j >= epsLo)) +
             sum(
-                Φ[k] * yAcc[t-(model.seasonality*k)] for
+                Φ[k] * arAcc[t-(model.seasonality*k)] for
                 k = 1:model.P if (t - (model.seasonality * k) >= yLo)
             ) +
             sum(Θ[w] * epsAcc[t-(model.seasonality*w)] for w = 1:model.Q if (t - (model.seasonality * w) >= epsLo))
@@ -1525,7 +1568,7 @@ function fit!(
             c +
             trend * driftValues[t] +
             sum(β[i] * exogValues[t, i] for i = 1:nExog) +
-            sum(ϕ[i] * yAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
+            sum(ϕ[i] * arAcc[t-i] for i = 1:model.p if (t - i >= yLo)) +
             sum(θ[j] * epsAcc[t-j] for j = 1:model.q if (t - j >= epsLo))
         )
     end
@@ -2796,6 +2839,20 @@ function predict(
 
     yValues::Vector{ModelFl} = deepcopy(values(diffY))
 
+    # Espelha a semantica da estimacao (ver `arAcc` em `fit!`). Sob :regression_errors o
+    # estado sobre o qual os termos AR recorrem e eta_t = y_t - X_t'b, e nao y_t; o bloco
+    # exogeno volta a entrar so no nivel, no fim de cada passo. Sob :armax `arValues` e o
+    # PROPRIO `yValues` (mesmo objeto), de modo que o `push!` alimenta os dois e o caminho
+    # historico fica bit-identico.
+    regErr::Bool =
+        !isnothing(model.exog) &&
+        get(model.metadata, "exogDynamics", "armax") == "regression_errors"
+    arValues::Vector{ModelFl} = if regErr
+        yValues .- valuesExog[1:length(yValues), :] * model.exogCoefficients
+    else
+        yValues
+    end
+
     driftFuture::Vector{ModelFl} = model.allowDrift ?
         differentiate(
             collect(ModelFl, 1:(length(values(model.y)) + stepsAhead)),
@@ -2807,10 +2864,10 @@ function predict(
         forecastedValue::ModelFl =
             model.c + (model.allowDrift ? model.trend * driftFuture[T+step] : model.trend)
         errorsLength = length(errors)
-        yLength = length(yValues)
+        yLength = length(arValues)
         if model.p > 0
             # ∑ϕᵢyₜ -i
-            forecastedValue += sum(model.ϕ[i] * yValues[end-i+1] for i = 1:model.p)
+            forecastedValue += sum(model.ϕ[i] * arValues[end-i+1] for i = 1:model.p)
         end
         if model.q > 0
             # ∑θᵢϵₜ-i
@@ -2822,7 +2879,7 @@ function predict(
         if model.P > 0
             # ∑Φₖyₜ-(s*k)
             forecastedValue += sum(
-                model.Φ[k] * yValues[end-(model.seasonality*k)+1] for
+                model.Φ[k] * arValues[end-(model.seasonality*k)+1] for
                 k = 1:model.P if (yLength - model.seasonality * k + 1 > 0)
             )
         end
@@ -2837,7 +2894,7 @@ function predict(
             if model.p > 0 && model.P > 0
                 for i = 1:model.p, k = 1:model.P
                     idx = yLength - i - model.seasonality * k + 1
-                    idx > 0 && (forecastedValue -= model.ϕ[i] * model.Φ[k] * yValues[idx])
+                    idx > 0 && (forecastedValue -= model.ϕ[i] * model.Φ[k] * arValues[idx])
                 end
             end
             if model.q > 0 && model.Q > 0
@@ -2847,15 +2904,21 @@ function predict(
                 end
             end
         end
-        if !isnothing(model.exog)
-            forecastedValue += valuesExog[T+step, :]'model.exogCoefficients
-        end
+        exogTerm::ModelFl =
+            isnothing(model.exog) ? zero(ModelFl) :
+            valuesExog[T+step, :]'model.exogCoefficients
+        regErr || (forecastedValue += exogTerm)
 
         ϵₜ = isSimulation ? rand(Normal(0, sqrt(model.σ²))) : 0
         forecastedValue += ϵₜ
 
         push!(errors, ϵₜ)
-        push!(yValues, forecastedValue)
+        if regErr
+            push!(arValues, forecastedValue)          # eta previsto alimenta a recursao AR
+            push!(yValues, forecastedValue + exogTerm)  # o nivel soma o bloco exogeno
+        else
+            push!(yValues, forecastedValue)           # arValues === yValues, alimentado junto
+        end
     end
     initialValuesLength = model.d + model.D * model.seasonality
     initialValuesOffset = length(values(model.y)) - initialValuesLength + 1

--- a/test/exog_dynamics.jl
+++ b/test/exog_dynamics.jl
@@ -1,0 +1,100 @@
+# Semantica do bloco exogeno: :armax vs :regression_errors.
+#
+# As duas equacoes (Hyndman, "The ARIMAX model muddle", 2010):
+#   :armax              phi(B) Phi(B^s) y_t = X_t'b + theta(B) Theta(B^s) e_t
+#   :regression_errors  y_t = X_t'b + eta_t ,  phi(B) Phi(B^s) eta_t = theta(B) Theta(B^s) e_t
+#
+# Os testes afirmam PROPRIEDADES DE SAIDA, nao internos: (i) o default nao mudou nada,
+# (ii) a identidade algebrica vale exatamente onde a algebra diz que vale e so ali, e
+# (iii) sob a forma de erros ARIMA o coeficiente recupera o efeito marginal do DGP.
+
+@testset "exogDynamics" begin
+    mkTA(v) = TimeArray(
+        collect(Date(2000, 1, 1):Month(1):Date(2000, 1, 1)+Month(length(v)-1)), v)
+    mkTX(X) = TimeArray(
+        collect(Date(2000, 1, 1):Month(1):Date(2000, 1, 1)+Month(size(X, 1)-1)), X)
+
+    "y = X*b + eta, com eta ~ ARMA(1,1)x(P,0,Q)[12]. P = 0 => polinomio AR unitario."
+    function geraErrosArima(seed, P; T = 120, S = 12, β = [2.0, -1.5])
+        rng = MersenneTwister(seed)
+        burn, K = 300, length(β)
+        n = burn + T
+        X, e = randn(rng, n, K), randn(rng, n)
+        ϕ, θ, Φ, Θ = 0.5, 0.4, (P > 0 ? 0.6 : 0.0), (P > 0 ? 0.0 : 0.7)
+        η = zeros(n)
+        for t = 14:n
+            η[t] = ϕ * η[t-1] + Φ * η[t-12] - ϕ * Φ * η[t-13] +
+                   e[t] + θ * e[t-1] + Θ * e[t-12] + θ * Θ * e[t-13]
+        end
+        y = X * β .+ η
+        rg = (n-T+1):n
+        (mkTA(y[rg]), mkTX(X[rg, :]))
+    end
+
+    ajusta(y, X, p, P, q, Q; kw...) = begin
+        m = SARIMA(y, X, p, 0, q; P = P, D = 0, Q = Q, seasonality = 12,
+                   allowMean = false, allowDrift = false)
+        fit!(m; objectiveFunction = "mse", initialization = :free,
+             stationary = true, invertible = false, kw...)
+        m
+    end
+
+    @testset "argumento invalido e recusado" begin
+        y, X = geraErrosArima(1, 1)
+        m = SARIMA(y, X, 1, 0, 1; P = 1, D = 0, Q = 0, seasonality = 12)
+        @test_throws ArgumentError fit!(m; exogDynamics = :naosei)
+    end
+
+    @testset "o default nao mudou: :armax e bit-identico a omitir o kwarg" begin
+        y, X = geraErrosArima(2, 1)
+        a = ajusta(y, X, 1, 1, 1, 0)
+        b = ajusta(y, X, 1, 1, 1, 0; exogDynamics = :armax)
+        @test a.exogCoefficients == b.exogCoefficients
+        @test a.ϕ == b.ϕ
+        @test a.Φ == b.Φ
+        @test a.θ == b.θ
+        predict!(a; stepsAhead = 6)
+        predict!(b; stepsAhead = 6)
+        @test values(a.forecast) == values(b.forecast)
+    end
+
+    # A IDENTIDADE. As duas formas coincidem sse o polinomio AR (regular e sazonal) e
+    # unitario e nao ha diferenciacao -- filtrar X por 1 nao faz nada. Fixar isto impede
+    # que uma refatoracao futura quebre a equivalencia em silencio.
+    @testset "p = P = 0: as duas semanticas sao a MESMA equacao" begin
+        y, X = geraErrosArima(3, 0)
+        a = ajusta(y, X, 0, 0, 1, 1)
+        b = ajusta(y, X, 0, 0, 1, 1; exogDynamics = :regression_errors)
+        @test a.exogCoefficients ≈ b.exogCoefficients atol = 1e-8
+        @test a.θ ≈ b.θ atol = 1e-8
+        @test a.Θ ≈ b.Θ atol = 1e-8
+        predict!(a; stepsAhead = 12)
+        predict!(b; stepsAhead = 12)
+        @test values(a.forecast) ≈ values(b.forecast) atol = 1e-6
+    end
+
+    # ... e so ali. Com p > 0 as duas TEM que divergir: se nao divergirem, o flag nao
+    # esta vinculando, que e a classe de defeito que ja custou caro neste pacote.
+    @testset "p > 0: as duas semanticas divergem (o flag vincula)" begin
+        y, X = geraErrosArima(4, 1)
+        a = ajusta(y, X, 1, 1, 1, 0)
+        b = ajusta(y, X, 1, 1, 1, 0; exogDynamics = :regression_errors)
+        predict!(a; stepsAhead = 12)
+        predict!(b; stepsAhead = 12)
+        @test maximum(abs.(values(a.forecast) .- values(b.forecast))) > 1e-3
+    end
+
+    # Sob a forma de erros ARIMA, b e o efeito marginal do DGP e tem de ser recuperado.
+    # Sob :armax, b e multiplicador de impacto e NAO tem essa interpretacao -- por isso
+    # o teste afirma so o lado que a teoria garante, e nao uma comparacao de erro.
+    @testset ":regression_errors recupera o efeito marginal" begin
+        β = [2.0, -1.5]
+        erros = Float64[]
+        for seed = 10:15
+            y, X = geraErrosArima(seed, 1; β = β)
+            m = ajusta(y, X, 1, 1, 1, 0; exogDynamics = :regression_errors)
+            push!(erros, maximum(abs.(Float64.([m.exogCoefficients...]) .- β)))
+        end
+        @test median(erros) < 0.25
+    end
+end

--- a/test/exog_dynamics.jl
+++ b/test/exog_dynamics.jl
@@ -14,11 +14,16 @@
     mkTX(X) = TimeArray(
         collect(Date(2000, 1, 1):Month(1):Date(2000, 1, 1)+Month(size(X, 1)-1)), X)
 
+    # `y` tem T pontos; `X` tem T + HMAX, porque o `predict!` exige o regressor futuro
+    # para o horizonte pedido -- e foi exatamente esse descasamento que fez a primeira
+    # versao deste arquivo lancar em vez de testar.
+    HMAX = 12
+
     "y = X*b + eta, com eta ~ ARMA(1,1)x(P,0,Q)[12]. P = 0 => polinomio AR unitario."
     function geraErrosArima(seed, P; T = 120, S = 12, β = [2.0, -1.5])
         rng = MersenneTwister(seed)
         burn, K = 300, length(β)
-        n = burn + T
+        n = burn + T + HMAX
         X, e = randn(rng, n, K), randn(rng, n)
         ϕ, θ, Φ, Θ = 0.5, 0.4, (P > 0 ? 0.6 : 0.0), (P > 0 ? 0.0 : 0.7)
         η = zeros(n)
@@ -27,8 +32,8 @@
                    e[t] + θ * e[t-1] + Θ * e[t-12] + θ * Θ * e[t-13]
         end
         y = X * β .+ η
-        rg = (n-T+1):n
-        (mkTA(y[rg]), mkTX(X[rg, :]))
+        rg = (n-T-HMAX+1):n
+        (mkTA(y[rg][1:T]), mkTX(X[rg, :]))
     end
 
     ajusta(y, X, p, P, q, Q; kw...) = begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,8 @@ using LinearAlgebra
 
     include("exact_ml_determinant.jl")
 
+    include("exog_dynamics.jl")
+
     include("multistart.jl")
 
     include("aqua.jl")


### PR DESCRIPTION
## The problem

With exogenous regressors the package estimates

```
phi(B) Phi(B^s) y_t = X_t'b + theta(B) Theta(B^s) e_t          (ARMAX)
```

while `forecast::Arima(..., xreg=)` estimates

```
y_t = X_t'b + eta_t ,  phi(B) Phi(B^s) eta_t = theta(B) Theta(B^s) e_t
```

The two coincide **iff** the AR polynomial (regular and seasonal) is unitary and there is no differencing. Outside that class they are different models, and `b` means different things: an impact multiplier under ARMAX, the usual marginal effect under regression with ARIMA errors.

Neither form is wrong — both are in the literature. What was missing is the **declaration**: nothing at the interface says which one is estimated, and a user arriving from `forecast` assumes the other. This is the confusion Hyndman named in ["The ARIMAX model muddle"](https://robjhyndman.com/hyndsight/arimax/) (2010); he recommends the regression-with-errors form precisely because of coefficient interpretability.

## Evidence

Three DGPs, 20 replicates each, order fixed at the truth on both sides, identical data. **All three signs were predicted before running.**

| DGP | RMSE ours | RMSE R | Δlog(RMSE) | b ours | b R |
|---|---|---|---|---|---|
| regression with ARIMA errors | 2.4686 | **1.6069** | **+0.4262** | [2.100, −1.587, 0.876] | [1.999, −1.501, 0.810] |
| pure MA (unitary AR) | 1.1212 | 1.1102 | **+0.0112** | [1.990, −1.499, 0.788] | [1.989, −1.499, 0.796] |
| ARMAX | **1.6582** | 2.4586 | **−0.4002** | [1.991, −1.495, 0.806] | [0.882, −0.624, 0.360] |

True b = [2.0, −1.5, 0.8]. Near-exact symmetry, and in the third row it is **R** that is misspecified, with the mirror-image attenuation.

This was found by a calibration gate, not by reading code: in a cell where all arms fit the same nested model, `b` was recovered correctly everywhere and yet R's RMSE was 33% lower. Correct coefficients with divergent forecasts is the signature of an impact multiplier read as a marginal effect.

**The M4 monthly run could not surface this** — it carries no exogenous regressors, so the whole exogenous path lies outside the benchmark that anchors our parity result.

## The change

`fit!` gains `exogDynamics::Symbol`, **default `:armax`** — the historical path is bit-identical and no existing caller changes result silently.

Under `:regression_errors` the AR terms recur on `eta_t = y_t − X_t'b` instead of `y_t`, and the exogenous block re-enters at the level. That is the whole change. Free pre-sample values already represent `eta` (there is no `X` before the sample starts), so they pass through untouched. The product `b*phi` makes the expression bilinear; the CSS objective is already non-convex through its MA terms, so the problem class is unchanged. `predict` mirrors it.

| | RMSE | Δlog vs R | b |
|---|---|---|---|
| `forecast::Arima` (target) | 1.6069 | — | [1.999, −1.501, 0.810] |
| `:armax` (default) | 2.4686 | +0.4262 | [2.100, −1.587, 0.876] |
| **`:regression_errors`** | **1.6135** | **+0.0020** CI95 [−0.0066, +0.0103] | **[2.000, −1.499, 0.810]** |

The residual +0.0020 sits inside the CSS-vs-ML resolution set by the middle row of the discriminator.

## Scope — measured, not assumed

**Validated for `d = D = 0` only.** I expected this to also fix the separately reported defect where `y` is differenced and `X` is merged raw. **It does not**: under `D = 1` both modes attenuate identically (median coefficient error **1.079** each), because that mismatch is at `sarima.jl:1193-1202`, which this PR does not touch.

## Tests

`test/exog_dynamics.jl` asserts **output properties**, not the formula:

- the default is bit-identical to omitting the kwarg;
- the two semantics coincide **exactly where the algebra says they must** (`p = P = 0`);
- and **diverge where they must** (`p > 0`) — otherwise the flag would not be binding, which is the defect class that has already cost this collaboration a measurement;
- the coefficient recovers the marginal effect under the regression-with-errors form.

Full suite green: **992 pass**, 1 pre-existing `@test_broken`. The file run standalone gives 12/12.

## Not in this PR

**Flipping the default.** That changes the numerical output of every existing caller and is a breaking-release decision — yours, not a keyword default. Davi's position is on record: adopt the R convention as the default target, on Hyndman's interpretability argument. This PR only makes the choice expressible.