### PR TITLE
Exogenous penalty must not depend on the order of the columns

### DIFF
--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -5554,9 +5554,16 @@ function regularizationObjective(jumpModel::Model, model::SARIMAModel, tolerance
         aux_vector = [jumpModel[param]...]
         aux_weights = []
         aux_lags = []
+        # O peso adaptativo e multiplicado pela POSICAO do parametro no bloco. Para phi,
+        # theta, Phi e Theta a posicao E a ordem da defasagem, e escalonar a penalidade
+        # com ela e deliberado: defasagem alta e menos parcimoniosa. Para :beta a posicao
+        # e a ordem em que o usuario passou as colunas exogenas, que nao tem ordenacao
+        # nenhuma -- com 120 regressores a ultima coluna pagaria 120x a penalidade da
+        # primeira, e trocar duas colunas de lugar mudaria o modelo selecionado.
+        posicaoImportaNaOrdem = param !== :β
         for (lag,el) in enumerate(aux_vector)
             push!(aux_weights, min(1/(abs(value(el)) + 1e-6), 1e6))
-            push!(aux_lags, lag * seasonalOffset)
+            push!(aux_lags, posicaoImportaNaOrdem ? lag * seasonalOffset : 1)
         end
 
         # get the median of the aux_weights

--- a/test/exog_penalty_position.jl
+++ b/test/exog_penalty_position.jl
@@ -1,0 +1,33 @@
+# A penalidade do elastic_net multiplica o peso adaptativo pela posicao do parametro no
+# bloco. Para phi/theta/Phi/Theta a posicao E a ordem da defasagem e o escalonamento e
+# deliberado. Para :beta a posicao e so a ordem em que o usuario passou as colunas, que
+# nao carrega informacao -- e a consequencia observavel e que PERMUTAR AS COLUNAS DE X
+# MUDA O MODELO. E essa a propriedade que o teste afirma, e nao a formula interna.
+@testset "penalidade exogena e invariante a permutacao das colunas" begin
+    Random.seed!(20250820)
+    T, S, K = 120, 12, 6
+    β = [2.0, 0.0, -1.5, 0.0, 0.0, 0.8]
+    X = randn(T, K)
+    ϵ = randn(T)
+    η = zeros(T)
+    for t = 2:T
+        η[t] = 0.5 * η[t-1] + ϵ[t]
+    end
+    y = X * β .+ η
+    datas = collect(Date(2000, 1, 1):Month(1):Date(2000, 1, 1)+Month(T-1))
+
+    ajusta(cols) = begin
+        m = SARIMA(TimeArray(datas, y), TimeArray(datas, X[:, cols]), 1, 0, 0;
+                   P = 0, D = 0, Q = 0, seasonality = S,
+                   allowMean = false, allowDrift = false)
+        fit!(m; objectiveFunction = "elastic_net", alpha = 1.0,
+             initialization = :free, stationary = true, invertible = false)
+        Float64.([m.exogCoefficients...])
+    end
+
+    direta = collect(1:K)
+    trocada = reverse(direta)
+    b1 = ajusta(direta)
+    b2 = ajusta(trocada)[sortperm(trocada)]   # desfaz a permutacao para comparar
+    @test b1 ≈ b2 atol = 1e-4
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -67,6 +67,8 @@ using LinearAlgebra
 
     include("exact_ml_determinant.jl")
 
+    include("exog_penalty_position.jl")
+
     include("multistart.jl")
 
     include("aqua.jl")


### PR DESCRIPTION
## The problem

In `regularizationObjective` the adaptive weight is multiplied by the parameter's **index within its block**:

```julia
push!(aux_lags, lag * seasonalOffset)
...
aux_weights = (aux_weights .* aux_lags)
```

For `phi`, `theta`, `Phi`, `Theta` the index **is** the lag order, and scaling the penalty with it is deliberate: a higher lag is less parsimonious. For `:beta` the index is the order in which the user happened to pass the exogenous columns, which carries no information.

**The observable consequence is that permuting the columns of `X` changes the model.** With 120 regressors the last column pays 120× the penalty of the first.

## Evidence — binding control run in both directions

6 regressors (3 relevant), `T = 120`, `elastic_net` with `alpha = 1`. The columns are reversed and the permutation undone before comparing:

| | b̂ direct order | b̂ with X permuted | max deviation |
|---|---|---|---|
| **without** the fix (`dev`) | [2.0458, 0, −1.1772, 0, −0, 0.4922] | [1.8678, 0, −1.0883, 0, 0, 0.7286] | **0.236341** |
| **with** the fix | [1.9791, 0, −1.1371, 0, 0, 0.5656] | [1.9791, 0, −1.1371, 0, 0, 0.5656] | **0.0** |

The test fails without the fix and passes with it — it **binds**. A test that passed on both sides would test nothing.

## The change

One line: do not apply the positional multiplier to the `:beta` block. **Does not touch the `mse` path**, so the pinned M4 parity configuration is unaffected.

## A correction to what I reported earlier

I described this weight as "positional". **Measured, it is subtler.** At `m = 120` **none** of the 123 weights saturates the `1e6` ceiling — it is genuine adaptive lasso on the CSS fit, and the three columns of the true support receive the **lowest** weights (0.188 / 0.173 / 0.237). The adaptive part works. The defect is only the positional multiplier stacked on top.

## Honest note on impact

In a 200-replicate sensitivity cell at `m = 120`, applying this fix left support recovery **unchanged** (F1 0.059 either way) and made forecasts slightly **worse** (+0.0288 in Δlog(RMSE), CI95 [+0.0065, +0.0522]).

That does not revoke the fix. Non-invariance to column permutation is a correctness defect regardless of whether it happened to help in one cell of one DGP. I am reporting the number so it is on the record rather than discovered later.

Full suite green: **981 pass**, 1 pre-existing `@test_broken`.