### PR TITLE
Do not flag outliers when interquartile dispersion is degenerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.0] - Unreleased
 
 ### Fixed
+- **`identifyOutliers` no longer flags every value that is not bit-identical to the
+  quartiles.** When the interquartile range is zero the IQR fences collapse onto `q1` and
+  `q3`, so the rule degenerates into an equality test against a float. `detectOutliers`
+  feeds it residuals that are JuMP variables tied by an equality constraint and satisfied
+  only up to the solver's tolerance, so which residuals count as "identical" is decided by
+  the last bit and therefore by the machine the solver ran on. Measured on the constant
+  fixture the old `detectOutliers` test used (`ones(31)` with one spike): 30 of the 31
+  residuals came out bit-identical here and exactly one outlier was reported, while shifting
+  three of them by 1-2 ULP — the difference between one runner and another — turns the
+  answer into four. That is the whole flake; the same two assertions failed with the same
+  values on unrelated branches, on whichever CI job happened to land on the other side.
+
+  `identifyOutliers` now returns no outliers when the IQR is below `DEGENERATE_IQR_RTOL`
+  (1e-8) times `max(|q1|, |q3|)`. The tolerance is **relative** to the data's own scale, and
+  the comparison is `<=` so that `q1 == q3 == 0` is covered too. Zero dispersion is zero
+  evidence of atypicality.
+
+  This inverts the contract for constant-plus-spike inputs — they now yield nothing — which
+  is why the `detectOutliers` fixture had to change with it: it now carries real dispersion
+  (IQR = 2 on a 10..14 pattern) plus an unambiguous spike, leaving a measured margin of
+  ~2.0 in data units between the outermost inlier and the fence, against solver noise of
+  order 1e-8. The degenerate case itself is covered directly, as a unit test over
+  constructed vectors, in `identifyOutliers dispersao degenerada`.
 - **The exact likelihood removed the wrong deterministic term.** Two conversions were
   missing in `exactLoglike`, both verified against `stats::arima(method = "ML")`:
   - `model.c` is the regression **constant**, not the mean. The level to remove is

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -351,6 +351,18 @@ end
 
 
 """
+Tolerância *relativa* abaixo da qual a amplitude interquartil é considerada degenerada,
+isto é, indistinguível de zero na escala dos próprios dados. Ver `identifyOutliers`.
+
+O valor acompanha a tolerância default do Ipopt (1e-8): os resíduos que alimentam
+`identifyOutliers` não são subtrações, são variáveis de um modelo JuMP amarradas por
+restrição de igualdade e satisfeitas apenas até a tolerância do solver. Fica ~8 ordens de
+grandeza acima do piso de ruído de ponto flutuante (ULP) e ~8 abaixo de qualquer dispersão
+com significado estatístico.
+"""
+const DEGENERATE_IQR_RTOL = 1e-8
+
+"""
     identifyOutliers(series::Vector{Fl}, method::String="iqr", threshold::Float64=1.5) where Fl<:AbstractFloat
 
 Identify outliers in a time series using the specified method.
@@ -362,6 +374,16 @@ Identify outliers in a time series using the specified method.
 
 # Returns
 A boolean vector indicating the outliers in the time series.
+
+# Dispersão degenerada
+
+Quando a amplitude interquartil é nula — ou pequena demais na escala dos dados, abaixo de
+`DEGENERATE_IQR_RTOL` vezes `max(|q1|, |q3|)` — a regra do IQR perde sentido: as cercas
+colapsam sobre os próprios quartis e *tudo* que não for bit-idêntico a eles é sinalizado.
+Nesse regime a resposta é nenhum outlier. Dispersão zero é evidência zero de atipicidade,
+e a diferença entre "igual" e "quase igual" ao quartil é ruído de tolerância numérica, não
+sinal. Sem essa guarda a saída da função depende do último bit dos resíduos e, portanto,
+do runner em que o solver rodou.
 """
 function identifyOutliers(
     series::Vector{Fl},
@@ -375,8 +397,17 @@ function identifyOutliers(
     if method == "iqr"
         q1 = quantile(series, 0.25)
         q3 = quantile(series, 0.75)
-        lower = q1 - threshold * (q3 - q1)
-        upper = q3 + threshold * (q3 - q1)
+        iqr = q3 - q1
+        # Guarda de dispersão degenerada. A comparação é relativa à escala dos quartis (e
+        # não a uma constante absoluta) para que a guarda signifique a mesma coisa em
+        # séries de qualquer magnitude. O `<=` cobre também `q1 == q3 == 0`, em que a
+        # escala é nula.
+        scale = max(abs(q1), abs(q3))
+        if iqr <= DEGENERATE_IQR_RTOL * scale
+            return falses(length(series))
+        end
+        lower = q1 - threshold * iqr
+        upper = q3 + threshold * iqr
         # make a list where 1 indicates an outlier and 0 indicates no outlier
         return (series .< lower) .| (series .> upper)
     end

--- a/test/models/sarima_auto.jl
+++ b/test/models/sarima_auto.jl
@@ -77,24 +77,39 @@
     end
 
     @testset "detectOutliers" begin
-        series = TimeArray(Dates.Date(2019, 1, 1):Dates.Day(1):Dates.Date(2019, 1, 31), ones(31))
+        # A fixture precisa ser NAO-DEGENERADA. A versao anterior era uma serie constante
+        # (`ones(31)`) com um unico pico: os 30 residuos restantes eram iguais, o IQR dava
+        # exatamente zero e as cercas colapsavam sobre a mediana, de modo que era sinalizado
+        # tudo que nao fosse bit-identico a ela. Como os residuos sao variaveis JuMP presas
+        # por restricao de igualdade — satisfeitas so ate a tolerancia do Ipopt — o conjunto
+        # de residuos "identicos" variava de runner para runner, e o teste alternava entre 1
+        # e 3 outliers detectados sem nenhuma mudanca de codigo.
+        #
+        # A base abaixo tem dispersao real (padrao 10..14, IQR = 2) mais um pico inequivoco.
+        # Medido: dispersao relativa ~0,54 e margem do inlier mais extremo ate a cerca ~2,0,
+        # contra ruido de solver da ordem de 1e-8. O resultado nao depende do ultimo bit.
+        dates = Dates.Date(2019, 1, 1):Dates.Day(1):Dates.Date(2019, 1, 31)
+        baseValues = [10.0 + ((i - 1) % 5) for i = 1:31]
+
+        series = TimeArray(dates, copy(baseValues))
         outliers = Sarimax.detectOutliers(series, nothing, 0, 0, 1, false)
         @test isnothing(outliers)
 
+        series = TimeArray(dates, copy(baseValues))
         values(series)[5] = 100
         outliers = Sarimax.detectOutliers(series, nothing, 0, 0, 1, false)
         @test isa(outliers, TimeSeries.TimeArray)
         @test length(colnames(outliers)) == 1
         @test colnames(outliers)[1] == Symbol("outlier_5")
 
-        values(series)[5] = 1
+        series = TimeArray(dates, copy(baseValues))
         values(series)[10] = 100
         outliers = Sarimax.detectOutliers(series, nothing, 0, 0, 1, false)
         @test isa(outliers, TimeSeries.TimeArray)
         @test length(colnames(outliers)) == 1
         @test colnames(outliers)[1] == Symbol("outlier_10")
 
-        values(series)[10] = 1
+        series = TimeArray(dates, copy(baseValues))
         values(series)[15] = 100
         outliers = Sarimax.detectOutliers(series, nothing, 0, 0, 1, false)
         @test isa(outliers, TimeSeries.TimeArray)
@@ -109,7 +124,7 @@
         @test colnames(outliers)[2] == Symbol("outlier_20")
 
         # test with exog
-        exog = TimeArray(Dates.Date(2019, 1, 1):Dates.Day(1):Dates.Date(2019, 1, 31), 2 .* ones(31))
+        exog = TimeArray(dates, 2 .* ones(31))
         outliers = Sarimax.detectOutliers(series, exog, 0, 0, 1, false)
         @test !isnothing(outliers)
         @test length(colnames(outliers)) == 3
@@ -117,6 +132,13 @@
         @test colnames(outliers)[2] == Symbol("outlier_15")
         @test colnames(outliers)[3] == Symbol("outlier_20")
 
+        # Contrato degenerado ponta a ponta: a fixture antiga (serie constante com um pico)
+        # agora nao produz outlier nenhum, porque a dispersao dos residuos e nula. E o outro
+        # lado da moeda do teste unitario em `identifyOutliers Tests` — e a razao pela qual
+        # a fixture acima precisou mudar, em vez de so a funcao.
+        degenerate = TimeArray(dates, ones(31))
+        values(degenerate)[5] = 100
+        @test isnothing(Sarimax.detectOutliers(degenerate, nothing, 0, 0, 1, false))
     end
 
     @testset "auto with default stepwise" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -240,6 +240,47 @@
         @test_throws ArgumentError Sarimax.identifyOutliers([1.0, 2.0, 3.0], "unknown")
     end
 
+    @testset "identifyOutliers dispersao degenerada" begin
+        # Contrato: IQR nulo — ou desprezivel na escala dos dados — implica nenhum outlier.
+        # Sem dispersao as cercas do IQR colapsam sobre os quartis e a regra passa a
+        # sinalizar tudo que nao for bit-identico a eles. Dispersao zero e evidencia zero de
+        # atipicidade. Testado como UNIDADE, sobre vetores construidos: uma fixture que roda
+        # o solver herdaria a tolerancia do solver, que e exatamente como o flake nasceu.
+
+        # Maioria identica mais um pico: sem dispersao central nao ha do que o pico destoar.
+        degenerateWithSpike = vcat(fill(5.0, 30), 100.0)
+        @test Sarimax.identifyOutliers(degenerateWithSpike) == falses(31)
+
+        # O flake medido, reconstruido a mao. Estes sao os residuos do ajuste SARIMA(0,0,0)
+        # da antiga fixture constante de `detectOutliers`, com tres valores deslocados de
+        # 1-2 ULP — a diferenca entre um runner e outro. Sem a guarda, as posicoes 7, 24 e 30
+        # aparecem como outliers junto da 5; com ela, nenhuma aparece, em qualquer runner.
+        base = -3.1935483870967762
+        solverNoise = fill(base, 31)
+        solverNoise[5] = 95.80645161290323
+        solverNoise[7] = prevfloat(base)
+        solverNoise[24] = nextfloat(base)
+        solverNoise[30] = nextfloat(base, 2)
+        @test Sarimax.identifyOutliers(solverNoise) == falses(31)
+
+        # Escala nula: os dois quartis em zero. A guarda usa `<=`, entao cobre este caso.
+        allZeros = zeros(20)
+        allZeros[3] = 1e-9
+        @test Sarimax.identifyOutliers(allZeros) == falses(20)
+
+        # Controle de vinculacao — a guarda tem de ficar MUDA quando ha dispersao de verdade.
+        # Mesma forma dos casos acima, mas com IQR real: o pico continua sendo sinalizado.
+        nonDegenerate = vcat(repeat([10.0, 11.0, 12.0, 13.0, 14.0], 6), 100.0)
+        @test findall(Sarimax.identifyOutliers(nonDegenerate)) == [31]
+
+        # E a dispersao minima que ainda NAO e degenerada segue tratada como dispersao:
+        # IQR relativo de 1e-6, cem vezes acima de `DEGENERATE_IQR_RTOL`, preserva a regra.
+        justAboveTolerance = fill(1.0, 30)
+        justAboveTolerance[1:15] .= 1.0 + 1e-6
+        push!(justAboveTolerance, 100.0)
+        @test findall(Sarimax.identifyOutliers(justAboveTolerance)) == [31]
+    end
+
     @testset "createOutliersDummies Tests" begin
         # Test with no outliers
         outliers1 = falses(5)


### PR DESCRIPTION
Fixes a flaky CI failure in `test/models/sarima_auto.jl` whose mechanism is floating-point, not statistical.

## The defect

`identifyOutliers` (`src/utils.jl`) fences on `q1 - 1.5*iqr` / `q3 + 1.5*iqr`. When the residual vector is (near-)constant, `iqr` collapses to **exactly 0.0** and the fences degenerate to the quartiles themselves — so *any* value differing in the last bit becomes an outlier. Which values those are is decided by the final bit of the solver output, so the count alternates between runs and between platforms.

## Reproduced, not inferred

Fitting the old fixture here, `model.ϵ` has **2 unique values, IQR exactly 0.0**, 1 outlier. Shifting 3 of the 30 equal residuals by **1–2 ULP** yields **4 outliers** (`[5, 7, 24, 30]`). The alternation is decided by the last bit.

## The fix

```julia
const DEGENERATE_IQR_RTOL = 1e-8
scale = max(abs(q1), abs(q3))
if iqr <= DEGENERATE_IQR_RTOL * scale
    return falses(length(series))
end
```

Tolerance is **relative to the quartile scale**, not absolute; `<=` also covers `q1 == q3 == 0`, where the scale itself is zero.

## Fixture also repaired

The base changes from `ones(31)` to `[10.0 + ((i-1) % 5) for i = 1:31]` (IQR = 2). This also fixes a **reset trap**: the old version restored with `values(series)[5] = 1`, which on a non-constant base would inject a *low* outlier. Each stage now rebuilds from `baseValues`.

## Guard fires only where intended — both directions checked

| case | without guard | with guard |
|---|---|---|
| `degenerateWithSpike` | `[31]` | guard fires |
| `solverNoise` | `[5,7,24,30]` | guard fires |
| `allZeros` | `[3]` | guard fires |
| `nonDegenerate`, `justAboveTolerance` (relative IQR 1e-6, **100× the tolerance**), `data1`, `data2`, `data3`, `data6` | — | **identical with and without** |

## Nothing else moves

SARIMA(1,0,1)(1,0,1)[12] on `airpassengers`, plus a `d=1` variant to exercise `trend`: `c`, `trend`, `ϕ`, `θ`, `Φ`, `Θ`, `σ²` and all residuals compared via `reinterpret(UInt64, ...)` — **405 lines bit-identical** against `dev`. Control: `dev`-vs-`dev` in separate processes is also identical, so the comparison measures what it claims to.

## Suite

Rebased onto `bbf8a97`: **1002 pass, 1 broken, 1003 total**. Julia 1.10.12 with a Manifest resolved from scratch: outlier cases **14/14**.

## Stated plainly

**The flake does not reproduce locally** on either 1.12.3 or 1.10.12 (both aarch64/macOS) — both land on the lucky side, with the 30 residuals bit-identical. The evidence that the fix works is the ULP-perturbation reproduction, now a unit test, not a before/after on the runner that was failing. Confirmation across the four CI jobs happens here.