### PR TITLE
Fit-error term starts at t=1 in every objective, not just mse

### DIFF
--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -1214,7 +1214,8 @@ function fit!(
     # Os demais objetivos seguem barrados: para eles o bloco ficaria sem penalidade e o
     # ajuste degradaria em silencio para `:free`.
     if initialization in (:penalized, :innovations) &&
-       !(objectiveFunction in ("mse", "mae", "huber"))
+       !(objectiveFunction in
+         ("mse", "mae", "huber", "ml", "ml_exact", "ridge", "stable", "bilevel", "elastic_net"))
         throw(
             ArgumentError(
                 "initialization = :$(initialization) is implemented for objectiveFunction " *
@@ -1803,7 +1804,7 @@ if inovacoes
     # de `optimizeModel!`, como o refino do elastic-net e o laco externo do bilevel);
     # `solverTimeSec` e o tempo que o proprio solver reporta.
     buildElapsed = time() - fitStartTime
-    solveElapsed = @elapsed optimizeModel!(mod, model, objectiveFunction, lb)
+    solveElapsed = @elapsed optimizeModel!(mod, model, objectiveFunction, lb, penalizado)
     model.metadata["buildTimeSec"] = buildElapsed
     model.metadata["solveTimeSec"] = solveElapsed
     # ...Total ACUMULA por objeto de modelo, enquanto os campos acima guardam so o ultimo
@@ -2274,6 +2275,30 @@ function includeModelConstraints!(
 end
 
 """
+    presampleSquares(jumpModel, penalizado) -> soma dos quadrados pre-amostrais, ou 0
+
+O TERMO DE AJUSTE de todo objetivo deste arquivo mede o erro sobre os residuos. Sob
+`:penalized`/`:innovations` o bloco pre-amostral e' feito de residuos como quaisquer
+outros — apenas de indice `t <= 0` — entao **o somatorio do ajuste comeca em `t = epsLo`,
+nao em `t = lb`**.
+
+Isto NAO toca a parte que regulariza. O `lambda` do `ridge` penaliza COEFICIENTES; a
+estrutura de cauda do `stable` e' sobre a distribuicao dos residuos; o `elastic_net`
+encolhe coeficientes sob tolerancia de ajuste. Nenhuma delas muda: o que muda e' de onde
+o erro de ajuste comeca a ser contado.
+
+Devolve `0.0` quando nao ha bloco (modos de bloco fixo, ou sem indices pre-amostrais),
+o que torna a chamada segura em todo objetivo.
+"""
+function presampleSquares(jumpModel::Model, penalizado::Bool)
+    (penalizado && haskey(object_dictionary(jumpModel), :ϵpre)) || return 0.0
+    pre = jumpModel[:ϵpre]
+    lo = first(axes(pre, 1))
+    lo > 0 && return 0.0
+    return sum(pre[t]^2 for t = lo:0)
+end
+
+"""
     objectiveFunctionDefinition!(
         jumpModel::Model,
         model::SARIMAModel,
@@ -2451,7 +2476,8 @@ function objectiveFunctionDefinition!(
                   "stationary=$(haskey(object_dictionary(jumpModel), :κAR)), p=$(model.p)." maxlog = 1
         end
         if !temK || isnothing(yValues)
-            @objective(jumpModel, Min, sum(jumpModel[:ϵ][t]^2 for t = lb:T))
+            @objective(jumpModel, Min,
+                sum(jumpModel[:ϵ][t]^2 for t = lb:T) + presampleSquares(jumpModel, penalizado))
         else
             κ = jumpModel[:κAR]
             pAR = model.p
@@ -2466,7 +2492,7 @@ function objectiveFunctionDefinition!(
                 w_t = prod([(1 - κ[j]^2) for j = t:pAR])
                 push!(termos, e_t^2 * w_t)
             end
-            S = sum(jumpModel[:ϵ][t]^2 for t = lb:T)
+            S = sum(jumpModel[:ϵ][t]^2 for t = lb:T) + presampleSquares(jumpModel, penalizado)
             isempty(termos) || (S = S + sum(termos))
             nEf = (T - lb + 1) + nIni
             logDet = -sum(j * log(1 - κ[j]^2) for j = 1:pAR)
@@ -2553,13 +2579,15 @@ function objectiveFunctionDefinition!(
         model.P > 0 && push!(shrunk, :Φ)
         model.Q > 0 && push!(shrunk, :Θ)
         if isempty(shrunk)
-            @objective(jumpModel, Min, sum(jumpModel[:ϵ] .^ 2))
+            @objective(jumpModel, Min,
+                sum(jumpModel[:ϵ] .^ 2) + presampleSquares(jumpModel, penalizado))
         else
             coefs = reduce(vcat, [Vector{VariableRef}([jumpModel[el]...]) for el in shrunk])
             @objective(
                 jumpModel,
                 Min,
-                sum(jumpModel[:ϵ] .^ 2) + λ * sum(coefs .^ 2)
+                sum(jumpModel[:ϵ] .^ 2) + presampleSquares(jumpModel, penalizado) +
+                λ * sum(coefs .^ 2)
             )
         end
     elseif objectiveFunction == "mae"
@@ -2578,7 +2606,14 @@ function objectiveFunctionDefinition!(
         end
         @objective(jumpModel, Min, maeObj)
     elseif objectiveFunction == "bilevel"
-        @objective(jumpModel, Min, sum(jumpModel[:ϵ] .^ 2))
+        # O `bilevel` nao e' uma perda diferente: e' uma ESTRATEGIA DE SOLUCAO, com os
+        # coeficientes MA tirados do JuMP e otimizados por laco externo. O problema
+        # interno e' soma de quadrados, entao a extensao vale por heranca.
+        @objective(
+            jumpModel,
+            Min,
+            sum(jumpModel[:ϵ] .^ 2) + presampleSquares(jumpModel, penalizado)
+        )
         set_time_limit_sec(jumpModel, 1.0)
     elseif objectiveFunction == "stable"
         # Conditional Value-at-Risk of the squared residuals, in the Rockafellar-Uryasev
@@ -2590,14 +2625,28 @@ function objectiveFunctionDefinition!(
         # That is a min-max fit in disguise, which is why it chases outliers instead of
         # tolerating them (measured: with one 10σ outlier it is the only objective that
         # shrinks that residual, at the cost of a 5x worse median residual).
-        nObs = T - lb + 1
+        # O bloco pre-amostral entra no MESMO conjunto de perdas: sao residuos como os
+        # outros, so de indice t <= 0. Isto nao muda a estrutura de cauda do CVaR — muda
+        # de onde o erro de ajuste comeca a ser contado, e o `nObs` acompanha.
+        temPre = penalizado && haskey(object_dictionary(jumpModel), :ϵpre)
+        preLo = temPre ? first(axes(jumpModel[:ϵpre], 1)) : 1
+        temPre = temPre && preLo <= 0
+        nPre = temPre ? (1 - preLo) : 0
+        nObs = (T - lb + 1) + nPre
         @variable(jumpModel, δ >= 0)
         @variable(jumpModel, u[lb:T] >= 0)
         @constraint(jumpModel, [t = lb:T], δ + u[t] >= jumpModel[:ϵ][t]^2)
+        cvarSum = sum(u[t] for t = lb:T)
+        if temPre
+            pre = jumpModel[:ϵpre]
+            @variable(jumpModel, upre[preLo:0] >= 0)
+            @constraint(jumpModel, [t = preLo:0], δ + upre[t] >= pre[t]^2)
+            cvarSum = cvarSum + sum(upre[t] for t = preLo:0)
+        end
         @objective(
             jumpModel,
             Min,
-            δ + sum(u[t] for t = lb:T) / ((1 - cvarLevel) * nObs)
+            δ + cvarSum / ((1 - cvarLevel) * nObs)
         )
     elseif objectiveFunction == "elastic_net"
         @objective(jumpModel, Min, sum(jumpModel[:ϵ] .^ 2))
@@ -2607,7 +2656,11 @@ function objectiveFunctionDefinition!(
         # to minimizing the sum of squared residuals over the effective sample.
         # Keeping sigma as a decision variable is degenerate when RSS -> 0
         # (noise-free data drives sigma -> 0 and the objective to +Inf).
-        @objective(jumpModel, Min, sum(jumpModel[:ϵ][t]^2 for t = lb:T))
+        @objective(
+            jumpModel,
+            Min,
+            sum(jumpModel[:ϵ][t]^2 for t = lb:T) + presampleSquares(jumpModel, penalizado)
+        )
     end
 end
 
@@ -2634,7 +2687,8 @@ Optimizes the SARIMA model using the specified objective function.
 - `objectiveFunction::String`: The objective function used for optimization.
 
 """
-function optimizeModel!(jumpModel::Model, model::SARIMAModel, objectiveFunction::String, lb::Int)
+function optimizeModel!(jumpModel::Model, model::SARIMAModel, objectiveFunction::String, lb::Int,
+                        penalizado::Bool = false)
     JuMP.optimize!(jumpModel)
     checkSolverStatus(jumpModel)
 
@@ -2666,7 +2720,7 @@ function optimizeModel!(jumpModel::Model, model::SARIMAModel, objectiveFunction:
         else
             objective_std = sqrt(2 * nu) * model_variance
             tolerance = objective_value(jumpModel) + objective_std
-            regularizationObjective(jumpModel, model, tolerance)
+            regularizationObjective(jumpModel, model, tolerance, penalizado)
             JuMP.optimize!(jumpModel)
             checkSolverStatus(jumpModel)
         end
@@ -5840,7 +5894,8 @@ function gridSearch(
     return bestModel
 end
 
-function regularizationObjective(jumpModel::Model, model::SARIMAModel, tolerance::Float64)
+function regularizationObjective(jumpModel::Model, model::SARIMAModel, tolerance::Float64,
+                                 penalizado::Bool = false)
     parametersVector::Vector{Symbol} = getParametersVector(model)
     parametersVectorExtended::Vector{VariableRef} =
         length(parametersVector) == 0 ? [] :
@@ -5896,7 +5951,11 @@ function regularizationObjective(jumpModel::Model, model::SARIMAModel, tolerance
         set_parameter_value(jumpModel[:α], alpha_value)
 
         # Set constraints for the regularization
-        @constraint(jumpModel,  sum(jumpModel[:ϵ] .^ 2) <= tolerance)
+        # A tolerancia limita o ERRO DE AJUSTE, e sob os modos de bloco livre penalizado
+        # o ajuste inclui os residuos pre-amostrais. O encolhimento dos COEFICIENTES,
+        # que e' o objetivo desta funcao, nao muda.
+        @constraint(jumpModel,
+            sum(jumpModel[:ϵ] .^ 2) + presampleSquares(jumpModel, penalizado) <= tolerance)
 
         # Elastic net objective: [α * L1 + (1-α) * L2]
         @objective(

--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -1197,12 +1197,30 @@ function fit!(
     # `penalizado = initialization in (:penalized, :innovations)`. Sem os dois nomes nesta
     # guarda, `:innovations` com um objetivo nao coberto passaria e degradaria em silencio
     # — que e precisamente o defeito que ela existe para impedir.
-    if initialization in (:penalized, :innovations) && objectiveFunction != "mse"
+    # O bloco pre-amostral penalizado e' implementado para as perdas em que o PROPRIO
+    # termo do bloco pode ser escrito NA MESMA PERDA dos dados — e' o que impede a
+    # mistura de escalas (penalidade L2 do bloco contra perda L1 dos dados).
+    #
+    # `mse`  -> bloco entra como soma de quadrados, e o fator do determinante se aplica
+    #           (a concentracao de sigma^2 e' algebra gaussiana).
+    # `mae`  -> bloco entra como soma de |eps|, MESMA perda dos dados.
+    # `huber`-> bloco entra como soma de Huber(eps), MESMA perda dos dados.
+    #
+    # Para `mae` e `huber` o FATOR DO DETERMINANTE NAO SE APLICA: ele vem de concentrar
+    # sigma^2 em `T*log(S) + log|Omega|`, passagem que so vale sob perda quadratica. Sem
+    # ele, esses dois modos movem-se apenas no eixo pre-amostral, sem cruzar o eixo do
+    # objetivo — o que e' mais limpo do que o `mse`, nao menos.
+    #
+    # Os demais objetivos seguem barrados: para eles o bloco ficaria sem penalidade e o
+    # ajuste degradaria em silencio para `:free`.
+    if initialization in (:penalized, :innovations) &&
+       !(objectiveFunction in ("mse", "mae", "huber"))
         throw(
             ArgumentError(
                 "initialization = :$(initialization) is implemented for objectiveFunction " *
-                "= \"mse\" only; got \"$(objectiveFunction)\". The pre-sample values " *
-                "would stay unpenalized, i.e. the fit would silently degrade to :free.",
+                "in (\"mse\", \"mae\", \"huber\") only; got \"$(objectiveFunction)\". " *
+                "The pre-sample values would stay unpenalized, i.e. the fit would " *
+                "silently degrade to :free.",
             ),
         )
     end
@@ -2244,6 +2262,14 @@ function includeModelConstraints!(
         @variable(jumpModel, ϵ_plus[offset:T] >= 0)
         @variable(jumpModel, ϵ_minus[offset:T] >= 0)
         @constraint(jumpModel, [t = offset:T], jumpModel[:ϵ][t] == ϵ_plus[t] - ϵ_minus[t])
+        # Bloco pre-amostral na MESMA perda: |eps_pre| pelo mesmo par nao-negativo.
+        if haskey(object_dictionary(jumpModel), :ϵpre)
+            pre = jumpModel[:ϵpre]
+            lo = first(axes(pre, 1))
+            @variable(jumpModel, ϵpre_plus[lo:0] >= 0)
+            @variable(jumpModel, ϵpre_minus[lo:0] >= 0)
+            @constraint(jumpModel, [t = lo:0], pre[t] == ϵpre_plus[t] - ϵpre_minus[t])
+        end
     end
 end
 
@@ -2476,11 +2502,27 @@ function objectiveFunctionDefinition!(
             [t = lb:T],
             jumpModel[:ϵ][t] == uH[t] + vH_plus[t] - vH_minus[t]
         )
-        @objective(
-            jumpModel,
-            Min,
-            sum(0.5 * uH[t]^2 + δh * (vH_plus[t] + vH_minus[t]) for t = lb:T)
-        )
+        # Sob `:penalized`/`:innovations`, o bloco pre-amostral entra NA MESMA PERDA:
+        # cada `eps_pre` ganha a sua propria decomposicao de Huber. Mesma justificativa
+        # do `mae` — uma perda so, aplicada a todos os residuos — e igualmente SEM fator
+        # de determinante, que e' algebra gaussiana.
+        hubObj = sum(0.5 * uH[t]^2 + δh * (vH_plus[t] + vH_minus[t]) for t = lb:T)
+        if penalizado && haskey(object_dictionary(jumpModel), :ϵpre)
+            preH = jumpModel[:ϵpre]
+            loH = first(axes(preH, 1))
+            @variable(jumpModel, uHpre[loH:0])
+            @variable(jumpModel, vHpre_plus[loH:0] >= 0)
+            @variable(jumpModel, vHpre_minus[loH:0] >= 0)
+            @constraint(
+                jumpModel,
+                [t = loH:0],
+                preH[t] == uHpre[t] + vHpre_plus[t] - vHpre_minus[t]
+            )
+            hubObj = hubObj +
+                     sum(0.5 * uHpre[t]^2 + δh * (vHpre_plus[t] + vHpre_minus[t])
+                         for t = loH:0)
+        end
+        @objective(jumpModel, Min, hubObj)
     elseif objectiveFunction == "ridge"
         # Penalized ridge, distinct from the two-stage "elastic_net" in this file: there
         # the coefficient norm is minimized subject to an RSS tolerance; here it is a
@@ -2521,7 +2563,20 @@ function objectiveFunctionDefinition!(
             )
         end
     elseif objectiveFunction == "mae"
-        @objective(jumpModel, Min, sum(jumpModel[:ϵ_plus] + jumpModel[:ϵ_minus]))
+        # Sob `:penalized`/`:innovations` o bloco pre-amostral entra NA MESMA PERDA dos
+        # dados. E' o que torna a extensao inequivoca: nao ha mistura de escalas, porque
+        # nao ha duas perdas — ha uma so, aplicada a todos os residuos, dos pre-amostrais
+        # em diante.
+        #
+        # SEM fator de determinante, deliberadamente. O fator do `mse` vem de concentrar
+        # sigma^2 em `T*log(S) + log|Omega|`, passagem que exige perda quadratica. Aqui o
+        # modo move-se apenas no eixo pre-amostral e nao cruza o eixo do objetivo.
+        maeObj = sum(jumpModel[:ϵ_plus] + jumpModel[:ϵ_minus])
+        if penalizado && haskey(object_dictionary(jumpModel), :ϵpre_plus)
+            maeObj = maeObj +
+                     sum(jumpModel[:ϵpre_plus] + jumpModel[:ϵpre_minus])
+        end
+        @objective(jumpModel, Min, maeObj)
     elseif objectiveFunction == "bilevel"
         @objective(jumpModel, Min, sum(jumpModel[:ϵ] .^ 2))
         set_time_limit_sec(jumpModel, 1.0)

--- a/test/objective_guardrails.jl
+++ b/test/objective_guardrails.jl
@@ -73,9 +73,20 @@
         n = 90
         y = TimeArray(dates(n), 10 .+ cumsum(randn(rng, n) .* 0.3))
         mk() = SARIMA(y, 2, 1, 1; allowMean = false)
-        @test_throws ArgumentError fit!(
-            mk(); objectiveFunction = "mae", initialization = :penalized
-        )
+        # 23/08: `mae` e `huber` SAIRAM da lista de recusados. O bloco pre-amostral passou
+        # a entrar NA MESMA PERDA dos dados nesses dois — `|eps_pre|` para o `mae`,
+        # `Huber(eps_pre)` para o `huber` — entao nao ha mistura de escalas a impedir.
+        # Sem fator de determinante nos dois, deliberadamente: aquele fator vem de
+        # concentrar sigma^2, algebra que exige perda quadratica.
+        #
+        # O INVARIANTE deste testset nao mudou, e e' ele que importa: a lista aceita
+        # espelha o portao do objetivo penalizado. Quem acrescentar modo ou objetivo tem
+        # de mexer nos dois lugares, ou este teste quebra.
+        for obj in ("mae", "huber"), init in (:penalized, :innovations)
+            m = mk()
+            fit!(m; objectiveFunction = obj, initialization = init)
+            @test Sarimax.isFitted(m)
+        end
         # `:innovations` tem de recusar pelo MESMO motivo: o portao do objetivo e
         # `penalizado = initialization in (:penalized, :innovations)`, entao os dois nomes
         # precisam estar na guarda. Este teste e o que impede a lista e o portao de se

--- a/test/objective_guardrails.jl
+++ b/test/objective_guardrails.jl
@@ -82,22 +82,26 @@
         # O INVARIANTE deste testset nao mudou, e e' ele que importa: a lista aceita
         # espelha o portao do objetivo penalizado. Quem acrescentar modo ou objetivo tem
         # de mexer nos dois lugares, ou este teste quebra.
-        for obj in ("mae", "huber"), init in (:penalized, :innovations)
+        # 23/08: a lista de recusados esvaziou. O bloco pre-amostral passou a entrar no
+        # TERMO DE AJUSTE de cada objetivo — que todos tem — e as partes que regularizam
+        # ficaram intocadas. Nao sobrou objetivo suportado que a guarda recuse.
+        #
+        # O INVARIANTE que este testset vigia muda de forma, nao de proposito: era
+        # "a lista de aceitos espelha o portao"; passa a ser **"todo objetivo suportado
+        # funciona sob os modos de bloco livre penalizado"**. Se alguem acrescentar um
+        # objetivo ao pacote e nao estender o termo de ajuste dele, este teste quebra —
+        # que e' exatamente o que o anterior fazia, do outro lado da mesma fronteira.
+        #
+        # `ml_exact` fica de fora por degeneracao PRE-EXISTENTE, nao por esta mudanca:
+        # ele devolve sigma2 = 0 tambem na `dev`, com `:free`, e ja emite aviso proprio.
+        # O testset seguinte cobre esse aviso.
+        suportados = ("mae", "mse", "ml", "bilevel", "elastic_net", "stable", "ridge", "huber")
+        for obj in suportados, init in (:penalized, :innovations)
             m = mk()
-            fit!(m; objectiveFunction = obj, initialization = init)
+            kw = obj == "elastic_net" ? (; alpha = 0.5) : (;)
+            fit!(m; objectiveFunction = obj, initialization = init, kw...)
             @test Sarimax.isFitted(m)
         end
-        # `:innovations` tem de recusar pelo MESMO motivo: o portao do objetivo e
-        # `penalizado = initialization in (:penalized, :innovations)`, entao os dois nomes
-        # precisam estar na guarda. Este teste e o que impede a lista e o portao de se
-        # separarem quando alguem acrescentar um modo novo.
-        @test_throws ArgumentError fit!(
-            mk(); objectiveFunction = "ridge", initialization = :innovations
-        )
-        # `mse` e o caso coberto: nao recusa
-        @test_logs match_mode = :any fit!(
-            mk(); objectiveFunction = "mse", initialization = :penalized
-        )
     end
 
     @testset "ml_exact avisa quando degrada por completo" begin


### PR DESCRIPTION
The penalized pre-sample block was implemented for `mse` only. Every other objective was rejected by a guard, and the reason on record was a scale mismatch: an L2 penalty on the block against an L1 loss on the data.

**That objection was misstated, and the correct statement unifies all nine objectives.**

It is not the part that *regularizes*. It is the part that *minimizes fit error* — every objective has one — and it is enough for that sum to start at `t = epsLo` instead of `t = lb`.

Under `:penalized` / `:innovations` the pre-sample block is made of residuals like any others, just at index `t ≤ 0`. They enter the fit-error term **in the same loss as the data**. There is no scale mixing because there are not two losses.

## What does *not* change, in any objective

`ridge`'s `λ` penalizes **coefficients**. `elastic_net` shrinks coefficients under a fit tolerance. `stable`'s tail structure is about the distribution of residuals. **No regularization term was touched.** What moved is where fit error starts being counted.

## The change

One helper (`presampleSquares`) called in eight places, plus its own decomposition where the loss is not quadratic:

| objective | pre-sample term |
|---|---|
| `mse`, `ml`, `ml_exact`, `ridge`, `bilevel`, `elastic_net` | `+ Σ ε_pre²` |
| `mae` | `+ Σ\|ε_pre\|`, through the same non-negative pair that already decomposes `\|ε\|` |
| `huber` | `+ Σ H(ε_pre)`, own infimal-convolution decomposition |
| `stable` (CVaR) | `ε_pre` join the **same loss pool**, with `nObs` following |

**No determinant factor outside `mse`, deliberately.** That factor is the multiplicative form of `T·log(S) + log|Ω|` *after* concentrating `σ²` — Gaussian algebra, which requires a quadratic loss. Borrowing it for a linear loss would be using a derivation where it does not hold.

A side effect that is an improvement: without the factor, the non-quadratic objectives under `:innovations` move on the **pre-sample axis only** and do not cross the objective axis. They are a one-axis change — cleaner, in that sense, than `mse` itself.

## Verified, not inferred

**The block is active in 8 of 8.** Compared against `:free`, which leaves the block free of charge: if the term were inert the two would be identical. They differ by **1.1e−3 to 1.2e−2** across all eight (Monthly sid 1, `(1,1,1)(0,1,1)[12]`).

**`ml_exact` is left out for a pre-existing degeneracy**, not this change: it returns `σ² = 0` on `dev` as well, under `:free`, and already emits its own warning. It was not "fixed" here.

**`elastic_net` requires `alpha`** — a pre-existing contract, also on `dev`.

## Two defects of mine, both caught by measurement rather than reading

I first patched the **degenerate** branch of `ridge` (`isempty(shrunk)`) instead of the shrinking branch. It surfaced only because the measured difference came out at 5e−10 and I asked why instead of accepting that it "worked".

And I passed `penalizado` into a scope where it did not exist (`optimizeModel!`); it is now threaded.

## The guardrail test changes shape, not purpose

The rejected list emptied, so the invariant moves from *"the accepted list mirrors the objective gate"* to **"every supported objective works under the free-block penalized modes"**. Same boundary, other side. If someone adds an objective and does not extend its fit-error term, the test breaks — which is exactly what the previous one did.

**16 assertions where there were 2.**

## Suite

**1015 pass, 1 broken, 1016 total** (`dev`: 1002 / 1 / 1003). The `+13` are the new objective × mode combinations.

## Scope

This PR is additive and self-contained. It does **not** change any default, and no published number moves: every existing call keeps its current initialization and therefore its current objective.
