### PR TITLE
Dois defeitos do warmStart: a semente de resíduos na escala errada, e o huber caindo em mse em silêncio

### DIFF
--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -1787,6 +1787,7 @@ if inovacoes
         warmStart,
         lb,
         T;
+        epsScale = yScale,
         stationary = stationary,
         invertible = invertible,
         stationarityMargin = stationarityMargin,
@@ -2102,6 +2103,7 @@ function applyWarmStart!(
     ws::SARIMAModel,
     lb::Int,
     T::Int;
+    epsScale::Real = 1,
     stationary::Bool,
     invertible::Bool,
     stationarityMargin::AbstractFloat,
@@ -2111,10 +2113,16 @@ function applyWarmStart!(
     clampκ(v, margin) = clamp(v, -(1 - margin - 1e-4), (1 - margin - 1e-4))
 
     if !isnothing(ws.ϵ) && haskey(od, :ϵ)
+        # `ws.ϵ` vem em unidades ORIGINAIS — o construtor devolve `value.(ϵ) .* yScale` —
+        # enquanto o `ϵ` deste modelo vive na escala padronizada (`yValues ./ yScale`).
+        # Semear o vetor cru punha a partida MAIS infactivel que a partida fria: medido em
+        # 28/08 pelo `inf_pr` da iteracao 0 do Ipopt, de ~13 para 337-7.720 em series daily.
+        # Sem esta divisao o `warmStart` e um chute grande, nao uma semente informada.
+        escala = (isfinite(epsScale) && epsScale > 0) ? epsScale : one(epsScale)
         ϵv = mod[:ϵ]
         n = min(length(ws.ϵ), T - lb + 1)
         for k = 1:n
-            set_start_value(ϵv[lb-1+k], ws.ϵ[k])
+            set_start_value(ϵv[lb-1+k], ws.ϵ[k] / escala)
         end
     end
 

--- a/src/models/sarima.jl
+++ b/src/models/sarima.jl
@@ -1096,6 +1096,15 @@ function fit!(
             ok = false
         end
         if !ok
+            # AVISAR, nunca degradar em silencio. O caller pediu `huber` e recebe um ajuste
+            # `mse`: sem aviso, uma celula inteira de experimento mede um estimador com o
+            # rotulo de outro. Medido em 28/08 no commit `aa68d57`: sob
+            # `initialization = :innovations` a guarda de objetivo lancava e este `catch`
+            # a engolia, com `huberFallback` em 40/40 series weekly — 100%, silenciosas, e
+            # o resultado devolvido era o `mse` bit a bit. Mesma politica dos PRs #11 e #12.
+            @warn "objectiveFunction=\"huber\" nao convergiu; devolvendo o ajuste \"mse\" " *
+                  "(metadata[\"huberFallback\"] = true). Toda medicao de huber deve reportar " *
+                  "a taxa de fallback como coluna de validade." maxlog = 1
             model.c = base.c
             model.trend = base.trend
             model.ϕ = base.ϕ

--- a/test/warm_start.jl
+++ b/test/warm_start.jl
@@ -122,4 +122,26 @@
         @test isapprox(Float64.(warm.θ), Float64.(cold.θ); atol = 1e-4)
     end
 
+    @testset "huber falling back to mse warns instead of degrading silently" begin
+        # The huber branch fits an `mse` base, tries huber, and on failure copies the whole
+        # `mse` model over, flagging only `metadata["huberFallback"]`. A caller that does not
+        # read the metadata gets one estimator under another's label. Measured on the M4
+        # campaign commit: under `initialization = :innovations` the objective guard threw and
+        # the bare `catch` swallowed it, so `huberFallback` was true in 40 of 40 weekly series.
+        # A time budget small enough to stop the huber solve reproduces the same path here.
+        Random.seed!(9182)
+        n = 120
+        dates = Date(2000, 1, 1):Day(1):(Date(2000, 1, 1)+Day(n - 1))
+        y = 1000.0 .+ cumsum(randn(n) .* 30.0)
+        model = SARIMA(TimeArray(collect(dates), y), 2, 1, 2; allowMean = false)
+
+        fit!(model; objectiveFunction = "huber", maxTimeSeconds = 1e-4)
+
+        # Whatever the solver decided, the flag must exist so a campaign can report the
+        # fallback rate as a validity column rather than discovering it after the fact.
+        @test haskey(model.metadata, "huberFallback")
+        @test model.metadata["huberFallback"] isa Bool
+        @test all(isfinite, model.ϕ)
+    end
+
 end

--- a/test/warm_start.jl
+++ b/test/warm_start.jl
@@ -89,4 +89,37 @@
         @test haskey(model.metadata, "solverStatus")
         @test all(isfinite, model.ϕ)
     end
+    @testset "the seeded residuals live on the model's internal scale" begin
+        # `ws.ϵ` is returned in ORIGINAL units (`value.(ϵ) .* yScale`), while this model's
+        # `ϵ` lives on the standardised scale (`yValues ./ yScale`). Seeding the raw vector
+        # made the warm start LESS feasible than a cold start — measured 28/08 through the
+        # iteration-0 `inf_pr` of Ipopt, which went from ~13 to 337-7720 on daily series.
+        # The scale is only visible when it is not 1, so this test uses a series whose
+        # standard deviation is far from unity; on a unit-variance series the bug hides.
+        Random.seed!(4711)
+        n = 250
+        dates = Date(2000, 1, 1):Day(1):(Date(2000, 1, 1)+Day(n - 1))
+        y = 5000.0 .+ cumsum(randn(n) .* 250.0)      # std(diff(y)) ~ 250, not ~1
+        ta = TimeArray(collect(dates), y)
+
+        cold = SARIMA(ta, 2, 1, 2; allowMean = false)
+        fit!(cold)
+
+        warm = SARIMA(ta, 2, 1, 2; allowMean = false)
+        fit!(warm; warmStart = cold)
+
+        # Seeded from the converged point of the same problem, the warm solve must not
+        # need more iterations than the cold one. With the raw seed it needed more,
+        # because the start violated every dynamic constraint by a factor of `yScale`.
+        itCold = get(cold.metadata, "solverIterations", missing)
+        itWarm = get(warm.metadata, "solverIterations", missing)
+        if !ismissing(itCold) && !ismissing(itWarm)
+            @test itWarm <= itCold
+        end
+
+        # And it must land on the same optimum, not merely converge somewhere.
+        @test isapprox(Float64.(warm.ϕ), Float64.(cold.ϕ); atol = 1e-4)
+        @test isapprox(Float64.(warm.θ), Float64.(cold.θ); atol = 1e-4)
+    end
+
 end


### PR DESCRIPTION
Dois defeitos do caminho de `warmStart`, medidos e consertados. Independentes entre si —
podem ser revisados commit a commit.

## 1. `2abd892` — a semente de resíduos ia na escala errada

`applyWarmStart!` copiava `ws.ϵ` cru para dentro de `ϵ`, mas os dois vivem em escalas
diferentes: o construtor devolve os resíduos em unidades originais (`value.(ϵ) .* yScale`)
e o modelo trabalha padronizado (`yValues ./ yScale`). A semente violava **toda** restrição
dinâmica por um fator `yScale`.

Verificado pelo teste não-circular do Ipopt — o `inf_pr` da iteração 0 — em séries daily da
M4, com `mse` semeado a partir de um ajuste `mse` do mesmo problema:

| série/T | antes | depois | iterações |
|---|---:|---:|---|
| 1/300 | 1,30e+01 | **4,80e-02** | 10 → 5 |
| 4099/600 | 1,12e+01 | **3,42e-01** | 17 → 7 |
| 4099/1500 | 1,35e+01 | **4,42e-02** | 12 → 6 |

Antes do conserto a partida quente era **menos** factível que a fria — ou seja, um chute
grande, não uma semente informada.

**Limitação declarada, e medida:** objetivos que acrescentam bloco próprio (`huber`, com as
variáveis da convolução ínfimo-convoluta, e `stable`, com `δ` e os `u[t]`) continuam com
esse bloco não semeado, e para eles o `inf_pr` inicial não cai. O conserto é da escala,
não da cobertura.

Teste novo em `test/warm_start.jl`, com série de desvio-padrão longe de 1 — **o defeito
some numa série de variância unitária**, que é por que ele sobreviveu à suíte.

## 2. `e53f682` — o `huber` degradava para `mse` em silêncio

O ramo do `huber` ajusta um `mse` de base, tenta o `huber` num `catch` nu e, quando falha,
copia o modelo `mse` inteiro — coeficientes, resíduos, σ², ajuste em amostra — marcando
apenas `metadata["huberFallback"] = true`. Quem não lê o metadado recebe um estimador com
o rótulo de outro.

Não é hipotético. Medido no commit **`aa68d57`**, o das campanhas M4: ali a guarda de
objetivo lança `ArgumentError` para `initialization = :innovations` com qualquer objetivo
que não seja `mse`, e este `catch` a engolia:

| initialization | `huberFallback` |
|---|---:|
| `:innovations` | **40/40 (100,0%)** |
| `:zeroed` | 0/40 (0,0%) |

e `auto(huber, :innovations)` devolvia ordem, sMAPE em quatro casas e coeficientes
**idênticos** a `auto(mse, :innovations)` em 5 de 5 séries.

O `catch` continua — recuar é a política certa quando o solver não converge de verdade —
mas agora ele fala, com `maxlog = 1` para não poluir um torneio inteiro do `auto`.

## Verificação

`Pkg.test()` completo no `dev` de hoje com as duas correções: **1044 passando, 0 falhas**,
5 `broken`/`skip` pré-existentes, 2m37s.

## Contexto

O defeito 2 é o mesmo mecanismo que me levou a perguntar, por e-mail, qual configuração
gerou a Tabela 6 do paper — rodada como a legenda descreve, no commit da campanha, a coluna
`huber` seria uma cópia da coluna MSE. Isso é conversa separada; este PR conserta o código.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Xg2Dbck1PP1fKFp8kzgU8
